### PR TITLE
Fix attribute parsing

### DIFF
--- a/src/CppAst/CppAst.csproj
+++ b/src/CppAst/CppAst.csproj
@@ -3,7 +3,7 @@
     <TargetFrameworks>netstandard2.0</TargetFrameworks>
     <VersionPrefix>0.8.0</VersionPrefix>
     <VersionSuffix>alpha</VersionSuffix>
-    <BuildNumber>007</BuildNumber>
+    <BuildNumber>011</BuildNumber>
     <PackageId>CppAst.cgnx</PackageId>
     <Description>CppAst is a .NET library providing a C/C++ parser for header files with access to the full AST, comments and macros</Description>
     <Copyright>Alexandre Mutel</Copyright>
@@ -25,7 +25,7 @@
     <PublishRepositoryUrl>true</PublishRepositoryUrl>
     <IncludeSymbols>true</IncludeSymbols>
     <SymbolPackageFormat>snupkg</SymbolPackageFormat>
-    <Version>0.8.0-alpha-007</Version>
+    <Version>0.8.0-alpha-011</Version>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
This PR fixes [Attributes on line preceding the function are not parsed](https://github.com/xoofx/CppAst.NET/issues/53).