### PR TITLE
Support variadic templates from STL

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,7 +17,7 @@ on:
 
 jobs:
   build:
-    runs-on: windows-latest
+    runs-on: windows-2019
 
     steps:
     - name: Checkout
@@ -26,10 +26,10 @@ jobs:
         submodules: true
         fetch-depth: 0
 
-    - name: Install .NET 7.0
+    - name: Install .NET 6.0
       uses: actions/setup-dotnet@v3
       with:
-        dotnet-version: '7.0.x'
+        dotnet-version: '6.0.x'
 
     - name: Build & test (Release)
       run: |

--- a/src/CppAst.Tests/CppAst.Tests.csproj
+++ b/src/CppAst.Tests/CppAst.Tests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net7.0</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
     <!-- Workaround for issue https://github.com/microsoft/ClangSharp/issues/129 -->
     <RuntimeIdentifier Condition="'$(RuntimeIdentifier)' == '' AND '$(PackAsTool)' != 'true'">$(NETCoreSdkRuntimeIdentifier)</RuntimeIdentifier>
     <IsPackable>false</IsPackable>

--- a/src/CppAst/CppAst.csproj
+++ b/src/CppAst/CppAst.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>netstandard2.0</TargetFrameworks>
+    <TargetFrameworks>net6.0</TargetFrameworks>
     <VersionPrefix>0.8.0</VersionPrefix>
     <VersionSuffix>alpha</VersionSuffix>
     <BuildNumber>014</BuildNumber>

--- a/src/CppAst/CppClass.cs
+++ b/src/CppAst/CppClass.cs
@@ -145,9 +145,9 @@ namespace CppAst
         public List<CppTemplateArgument> TemplateSpecializedArguments { get; } = new List<CppTemplateArgument>();
 
         /// <summary>
-        /// Gets the specialized class template of this instance.
+        /// The primary, unspecialized class template of this instance.
         /// </summary>
-        public CppClass SpecializedTemplate { get; set; }
+        public CppClass PrimaryTemplate { get; set; }
 
 
         public bool IsEmbeded => Parent is CppClass;

--- a/src/CppAst/CppElement.cs
+++ b/src/CppAst/CppElement.cs
@@ -46,7 +46,7 @@ namespace CppAst
                         }
                         p = ns.Parent;
                     }
-                    else if (p is CppCompilation)
+                    else if (p is CppGlobalDeclarationContainer)
                     {
                         // root namespace here, just ignore~
                         p = null;

--- a/src/global.json
+++ b/src/global.json
@@ -1,6 +1,6 @@
 {
   "sdk": {
-    "version": "7.0.100",
+    "version": "6.0.100",
     "rollForward": "latestMinor",
     "allowPrerelease": false
   }


### PR DESCRIPTION
This commit adds the support for variadic templates as long as they are coming from the standard library. It was achieved by supporting the Pack type of CXTemplateArgumentKind.
This commit also fixed a bug of getting the full name of a CppElement so it does not throw a lot of unexpected exceptions.