### PR TITLE
Try to parse unexposed types as template parameters

### DIFF
--- a/src/CppAst/CppModelBuilder.cs
+++ b/src/CppAst/CppModelBuilder.cs
@@ -1820,7 +1820,11 @@ namespace CppAst
                         {
                             return GetCppType(type.Declaration, type.Declaration.Type, parent, data);
                         }
-
+                        var templateParameterType = TryToCreateTemplateParameters(cursor, data);
+                        if (templateParameterType != null)
+                        {
+                            return templateParameterType;
+                        }
                         var cppUnexposedType = new CppUnexposedType(type.ToString()) { SizeOf = (int)type.SizeOf };
                         var templateParameters = ParseTemplateSpecializedArguments(cursor, type, new CXClientData((IntPtr)data));
                         if (templateParameters != null)


### PR DESCRIPTION
The template parameter types such as "T" shows up as CXType_Unexposed in Clang, while they could still be represented as a template parameter type. This commit tries to parse them as a template parameter type so they are properly parsed within functions and fields.