### PR TITLE
Default templated arguments are not working

### DIFF
--- a/src/CppAst.Tests/TestFunctions.cs
+++ b/src/CppAst.Tests/TestFunctions.cs
@@ -368,5 +368,51 @@ void function0(T t);
             );
         }
 
+
+        [Test]
+        public void TestFunctionTemplateClass()
+        {
+            ParseAssert(@"
+
+template<typename T, int S>
+class Test
+{
+public:
+  Test(T t) : t_{t} {}
+private:
+  T t_;
+};
+
+static Test<int,2> aa{4};
+static Test<double,3> bb{6.0};
+
+void functionZ(int a = 5, double b = 6.5);
+void functionY(Test<int,2> a, Test<double,3> b);
+void functionX(Test<int,2> a = aa, Test<double,3> b = bb);
+",
+                compilation =>
+                {
+                    Assert.False(compilation.HasErrors);
+
+                    Assert.AreEqual(3, compilation.Functions.Count);
+
+                    {
+                        Assert.AreEqual(2, compilation.Functions[0].DefaultParamCount);
+                        Assert.True(compilation.Functions[0].Parameters[0].InitExpression is CppLiteralExpression);
+                        Assert.AreEqual("5", (compilation.Functions[0].Parameters[0].InitExpression as CppLiteralExpression).Value);
+                        Assert.True(compilation.Functions[0].Parameters[1].InitExpression is CppLiteralExpression);
+                        Assert.AreEqual("6.5", (compilation.Functions[0].Parameters[1].InitExpression as CppLiteralExpression).Value);
+                        Assert.AreEqual(0, compilation.Functions[1].DefaultParamCount);
+                        Assert.AreEqual(2, compilation.Functions[2].DefaultParamCount);
+                        Assert.True(compilation.Functions[2].Parameters[0].InitExpression is CppRawExpression);
+                        Assert.AreEqual("=aa", (compilation.Functions[2].Parameters[0].InitExpression as CppRawExpression).Text);
+                        Assert.True(compilation.Functions[2].Parameters[1].InitExpression is CppRawExpression);
+                        Assert.AreEqual("=bb", (compilation.Functions[2].Parameters[1].InitExpression as CppRawExpression).Text);
+                    }
+
+                }
+            );
+        }
+
     }
 }

--- a/src/CppAst.Tests/TestFunctions.cs
+++ b/src/CppAst.Tests/TestFunctions.cs
@@ -405,9 +405,9 @@ void functionX(Test<int,2> a = aa, Test<double,3> b = bb);
                         Assert.AreEqual(0, compilation.Functions[1].DefaultParamCount);
                         Assert.AreEqual(2, compilation.Functions[2].DefaultParamCount);
                         Assert.True(compilation.Functions[2].Parameters[0].InitExpression is CppRawExpression);
-                        Assert.AreEqual("=aa", (compilation.Functions[2].Parameters[0].InitExpression as CppRawExpression).Text);
+                        Assert.AreEqual("aa", (compilation.Functions[2].Parameters[0].InitExpression as CppRawExpression).Text);
                         Assert.True(compilation.Functions[2].Parameters[1].InitExpression is CppRawExpression);
-                        Assert.AreEqual("=bb", (compilation.Functions[2].Parameters[1].InitExpression as CppRawExpression).Text);
+                        Assert.AreEqual("bb", (compilation.Functions[2].Parameters[1].InitExpression as CppRawExpression).Text);
                     }
 
                 }

--- a/src/CppAst/CppModelBuilder.cs
+++ b/src/CppAst/CppModelBuilder.cs
@@ -1187,7 +1187,9 @@ namespace CppAst
             if (expression is CppRawExpression tokensExpr)
             {
                 var tokenizer = new CppTokenUtil.Tokenizer(cursor);
-                for (int i = 0; i < tokenizer.Count; i++)
+                // We don't need the first = character, if there is one
+                var startIndex = tokenizer.Count > 0 && tokenizer[0].Text == "=" ? 1 : 0;
+                for (int i = startIndex; i < tokenizer.Count; i++)
                 {
                     tokensExpr.Tokens.Add(tokenizer[i]);
                 }


### PR DESCRIPTION
If using the visitor pattern with libclang to check the list of function arguments, it is impossible to differentiate default arguments from template arguments. The reason is the libclang within its VisitTemplateSpecializationTypeLoc  function first sends back a TemplateRef with the actual template being used, right after that it sends back (some of) the template arguments. However the template arguments are sent back as the same literal expressions like a normal =5 expression, so it is impossible to differentiate if the received expression is actually a default argument or a template parameter. To overcome this issue default argument handling for parameters are done differently from this time on, as CXCursor has a built-in feature to fetch the default argument for the cursor.
