### PR TITLE
Fixing partial template specialization

### DIFF
--- a/src/CppAst.Tests/TestMisc.cs
+++ b/src/CppAst.Tests/TestMisc.cs
@@ -50,5 +50,79 @@ private:
                 }
             );
         }
+
+        [Test]
+        public void TestPartialSpecialization()
+        {
+            ParseAssert(@"
+
+template <typename T, int N>
+class ArrayBase
+{
+public:
+  ArrayBase(T array[N]) { for(int i=0;i<N;i++) array_[i] = array_[i]; }
+private:
+  T array_[N];
+};
+
+template <typename T>
+class Array2d : public ArrayBase<T, 2>
+{
+public:
+  using ArrayBase<T,2>::ArrayBase;
+};
+
+using Array2i = Array2d<int>;
+
+#include <array>
+
+template <typename T, int N>
+class VectorBase : public virtual std::array<T, N>
+{
+};
+
+template <typename T>
+class Vector2d : public VectorBase<T, 2>
+{
+public:
+  Vector2d(const std::array<T, 2> & elements = {0, 0})
+      : Vector2d<T>(elements[0], elements[1]) {}
+
+  Vector2d(T x, T y)
+  {
+    (*this)[0] = x, (*this)[1] = y;
+  }
+};
+
+using Vect2i = Vector2d<int32_t>;
+",
+                compilation =>
+                {
+                    Assert.False(compilation.HasErrors);
+                    Assert.AreEqual(6, compilation.Classes.Count);
+                    Assert.AreEqual(CppTemplateKind.TemplateClass, compilation.Classes[0].TemplateKind);
+                    Assert.AreEqual(2, compilation.Classes[0].TemplateParameters.Count);
+                    Assert.AreEqual(CppTemplateKind.TemplateClass, compilation.Classes[1].TemplateKind);
+                    Assert.AreEqual(1, compilation.Classes[1].BaseTypes.Count);
+                    Assert.True(compilation.Classes[1].BaseTypes[0].Type is CppClass);
+                    Assert.AreEqual(2, (compilation.Classes[1].BaseTypes[0].Type as CppClass).TemplateParameters.Count);
+                    Assert.AreEqual(0, (compilation.Classes[1].BaseTypes[0].Type as CppClass).TemplateSpecializedArguments.Count);
+                    Assert.AreEqual(1, compilation.Classes[1].TemplateSpecializedArguments.Count);
+                    Assert.AreEqual(CppTemplateKind.TemplateSpecializedClass, compilation.Classes[2].TemplateKind);
+                    Assert.AreEqual(2, compilation.Classes[2].TemplateSpecializedArguments.Count);
+
+                    Assert.AreEqual(CppTemplateKind.TemplateClass, compilation.Classes[3].TemplateKind);
+                    Assert.AreEqual(2, compilation.Classes[3].TemplateParameters.Count);
+                    Assert.AreEqual(CppTemplateKind.TemplateClass, compilation.Classes[4].TemplateKind);
+                    Assert.AreEqual(1, compilation.Classes[4].BaseTypes.Count);
+                    Assert.True(compilation.Classes[4].BaseTypes[0].Type is CppClass);
+                    Assert.AreEqual(2, (compilation.Classes[4].BaseTypes[0].Type as CppClass).TemplateParameters.Count);
+                    Assert.AreEqual(0, (compilation.Classes[4].BaseTypes[0].Type as CppClass).TemplateSpecializedArguments.Count);
+                    Assert.AreEqual(1, compilation.Classes[4].TemplateSpecializedArguments.Count);
+                    Assert.AreEqual(CppTemplateKind.TemplateSpecializedClass, compilation.Classes[5].TemplateKind);
+                    Assert.AreEqual(2, compilation.Classes[5].TemplateSpecializedArguments.Count);
+                }
+            );
+        }
     }
 }

--- a/src/CppAst.Tests/TestTypes.cs
+++ b/src/CppAst.Tests/TestTypes.cs
@@ -344,11 +344,22 @@ public:
   TemplatedClass2D operator-(const TemplatedClass2D& other) const;
 };
 
+template <typename T>
+class TemplatedClass3D : public virtual TemplatedClass<T, 3>
+{
+public:
+  TemplatedClass3D(T value);
+
+  TemplatedClass3D<T> operator+(const TemplatedClass3D<T>& other) const;
+
+  TemplatedClass3D operator-(const TemplatedClass3D& other) const;
+};
+
 ",
             compilation =>
             {
                 Assert.False(compilation.HasErrors);
-                Assert.AreEqual(compilation.Classes.Count, 2);
+                Assert.AreEqual(compilation.Classes.Count, 3);
                 {
                     var templatedClass = compilation.Classes[0];
                     Assert.AreEqual(templatedClass.Name, "TemplatedClass");
@@ -411,7 +422,7 @@ public:
                     var other2Type = ((other2.Type as CppReferenceType).ElementType as CppQualifiedType).ElementType as CppClass;
                     Assert.AreEqual(other2Type.TemplateKind, CppTemplateKind.TemplateClass);
                     Assert.AreEqual(other2Type.TemplateParameters.Count, 2);
-                    Assert.AreEqual(otherType.TemplateSpecializedArguments.Count, 0);
+                    Assert.AreEqual(other2Type.TemplateSpecializedArguments.Count, 0);
                     Assert.AreEqual(other2Type.Name, "TemplatedClass");
 
                     T = other2Type.TemplateParameters[0];
@@ -431,12 +442,16 @@ public:
                     Assert.AreEqual(templatedClass2D.Functions.Count, 2);
                     Assert.AreEqual(templatedClass2D.TemplateKind, CppTemplateKind.TemplateClass);
                     Assert.AreEqual(templatedClass2D.TemplateParameters.Count, 1);
-                    Assert.AreEqual(templatedClass2D.TemplateSpecializedArguments.Count, 0);
+                    Assert.AreEqual(templatedClass2D.TemplateSpecializedArguments.Count, 1);
 
 
                     var T = templatedClass2D.TemplateParameters[0];
                     Assert.True(T is CppTemplateParameterType);
                     Assert.AreEqual((T as CppTemplateParameterType).Name, "T");
+
+                    var N = templatedClass2D.TemplateSpecializedArguments[0];
+                    Assert.AreEqual(N.ArgKind, CppTemplateArgumentKind.AsInteger);
+                    Assert.AreEqual(2, N.ArgAsInteger);
 
                     var baseClass = templatedClass2D.BaseTypes[0].Type as CppClass;
                     Assert.AreEqual(baseClass, compilation.Classes[0]);
@@ -452,12 +467,16 @@ public:
                     var otherType = ((other.Type as CppReferenceType).ElementType as CppQualifiedType).ElementType as CppClass;
                     Assert.AreEqual(otherType.TemplateKind, CppTemplateKind.TemplateClass);
                     Assert.AreEqual(otherType.TemplateParameters.Count, 1);
-                    Assert.AreEqual(otherType.TemplateSpecializedArguments.Count, 0);
+                    Assert.AreEqual(otherType.TemplateSpecializedArguments.Count, 1);
                     Assert.AreEqual(otherType.Name, "TemplatedClass2D");
 
                     T = otherType.TemplateParameters[0];
                     Assert.True(T is CppTemplateParameterType);
                     Assert.AreEqual((T as CppTemplateParameterType).Name, "T");
+
+                    N = otherType.TemplateSpecializedArguments[0];
+                    Assert.AreEqual(N.ArgKind, CppTemplateArgumentKind.AsInteger);
+                    Assert.AreEqual(2, N.ArgAsInteger);
 
                     var operatorMinus = templatedClass2D.Functions[1];
                     Assert.AreEqual(operatorMinus.Name, "operator-");
@@ -470,14 +489,83 @@ public:
                     var other2Type = ((other2.Type as CppReferenceType).ElementType as CppQualifiedType).ElementType as CppClass;
                     Assert.AreEqual(other2Type.TemplateKind, CppTemplateKind.TemplateClass);
                     Assert.AreEqual(other2Type.TemplateParameters.Count, 1);
-                    Assert.AreEqual(otherType.TemplateSpecializedArguments.Count, 0);
+                    Assert.AreEqual(other2Type.TemplateSpecializedArguments.Count, 1);
                     Assert.AreEqual(other2Type.Name, "TemplatedClass2D");
 
                     T = other2Type.TemplateParameters[0];
                     Assert.True(T is CppTemplateParameterType);
                     Assert.AreEqual((T as CppTemplateParameterType).Name, "T");
 
+                    N = other2Type.TemplateSpecializedArguments[0];
+                    Assert.AreEqual(N.ArgKind, CppTemplateArgumentKind.AsInteger);
+                    Assert.AreEqual(2, N.ArgAsInteger);
                 }
+
+                {
+                    var templatedClass3D = compilation.Classes[2];
+                    Assert.AreEqual(templatedClass3D.Name, "TemplatedClass3D");
+                    Assert.AreEqual(templatedClass3D.Constructors.Count, 1);
+                    Assert.AreEqual(templatedClass3D.Functions.Count, 2);
+                    Assert.AreEqual(templatedClass3D.TemplateKind, CppTemplateKind.TemplateClass);
+                    Assert.AreEqual(templatedClass3D.TemplateParameters.Count, 1);
+                    Assert.AreEqual(templatedClass3D.TemplateSpecializedArguments.Count, 1);
+
+                    var T = templatedClass3D.TemplateParameters[0];
+                    Assert.True(T is CppTemplateParameterType);
+                    Assert.AreEqual((T as CppTemplateParameterType).Name, "T");
+
+                    var N = templatedClass3D.TemplateSpecializedArguments[0];
+                    Assert.AreEqual(N.ArgKind, CppTemplateArgumentKind.AsInteger);
+                    Assert.AreEqual(3, N.ArgAsInteger);
+
+                    var baseClass = templatedClass3D.BaseTypes[0].Type as CppClass;
+                    Assert.AreEqual(baseClass, compilation.Classes[0]);
+
+                    var operatorPlus = templatedClass3D.Functions[0];
+                    Assert.AreEqual(operatorPlus.Name, "operator+");
+
+                    Assert.AreEqual(operatorPlus.Parameters.Count, 1);
+                    var other = operatorPlus.Parameters[0];
+                    Assert.AreEqual(other.Name, "other");
+                    Assert.AreEqual(other.Type.TypeKind, CppTypeKind.Reference); // ref
+                    Assert.AreEqual((other.Type as CppReferenceType).ElementType.TypeKind, CppTypeKind.Qualified); // const
+                    var otherType = ((other.Type as CppReferenceType).ElementType as CppQualifiedType).ElementType as CppClass;
+                    Assert.AreEqual(otherType.TemplateKind, CppTemplateKind.TemplateClass);
+                    Assert.AreEqual(otherType.TemplateParameters.Count, 1);
+                    Assert.AreEqual(otherType.TemplateSpecializedArguments.Count, 1);
+                    Assert.AreEqual(otherType.Name, "TemplatedClass3D");
+
+                    T = otherType.TemplateParameters[0];
+                    Assert.True(T is CppTemplateParameterType);
+                    Assert.AreEqual((T as CppTemplateParameterType).Name, "T");
+
+                    N = otherType.TemplateSpecializedArguments[0];
+                    Assert.AreEqual(N.ArgKind, CppTemplateArgumentKind.AsInteger);
+                    Assert.AreEqual(3, N.ArgAsInteger);
+
+                    var operatorMinus = templatedClass3D.Functions[1];
+                    Assert.AreEqual(operatorMinus.Name, "operator-");
+
+                    Assert.AreEqual(operatorMinus.Parameters.Count, 1);
+                    var other2 = operatorMinus.Parameters[0];
+                    Assert.AreEqual(other2.Name, "other");
+                    Assert.AreEqual(other2.Type.TypeKind, CppTypeKind.Reference); // ref
+                    Assert.AreEqual((other2.Type as CppReferenceType).ElementType.TypeKind, CppTypeKind.Qualified); // const
+                    var other2Type = ((other2.Type as CppReferenceType).ElementType as CppQualifiedType).ElementType as CppClass;
+                    Assert.AreEqual(other2Type.TemplateKind, CppTemplateKind.TemplateClass);
+                    Assert.AreEqual(other2Type.TemplateParameters.Count, 1);
+                    Assert.AreEqual(other2Type.TemplateSpecializedArguments.Count, 1);
+                    Assert.AreEqual(other2Type.Name, "TemplatedClass3D");
+
+                    T = other2Type.TemplateParameters[0];
+                    Assert.True(T is CppTemplateParameterType);
+                    Assert.AreEqual((T as CppTemplateParameterType).Name, "T");
+
+                    N = other2Type.TemplateSpecializedArguments[0];
+                    Assert.AreEqual(N.ArgKind, CppTemplateArgumentKind.AsInteger);
+                    Assert.AreEqual(3, N.ArgAsInteger);
+                }
+
             });
 
 

--- a/src/CppAst/CppBaseType.cs
+++ b/src/CppAst/CppBaseType.cs
@@ -3,6 +3,7 @@
 // See license.txt file in the project root for full license information.
 
 using System;
+using System.Collections.Generic;
 using System.Text;
 
 namespace CppAst
@@ -35,6 +36,11 @@ namespace CppAst
         /// Gets the C++ type associated.
         /// </summary>
         public CppType Type { get; }
+
+        /// <summary>
+        /// Specialized template parameters for the given instance of the base type
+        /// </summary>
+        public List<CppTemplateArgument> TemplateSpecializedArguments { get; } = new List<CppTemplateArgument>();
 
         /// <inheritdoc />
         public override string ToString()

--- a/src/CppAst/CppTemplateArgument.cs
+++ b/src/CppAst/CppTemplateArgument.cs
@@ -22,15 +22,15 @@ namespace CppAst
 
         public CppTemplateArgument(CppType sourceParam, long intArg) : base(CppTypeKind.TemplateArgumentType)
         {
-			SourceParam = sourceParam ?? throw new ArgumentNullException(nameof(sourceParam));
+            SourceParam = sourceParam ?? throw new ArgumentNullException(nameof(sourceParam));
             ArgAsInteger = intArg;
             ArgKind = CppTemplateArgumentKind.AsInteger;
             IsSpecializedArgument = true;
         }
 
-		public CppTemplateArgument(CppType sourceParam, string unknownStr) : base(CppTypeKind.TemplateArgumentType)
+        public CppTemplateArgument(CppType sourceParam, string unknownStr) : base(CppTypeKind.TemplateArgumentType)
         {
-			SourceParam = sourceParam ?? throw new ArgumentNullException(nameof(sourceParam));
+            SourceParam = sourceParam ?? throw new ArgumentNullException(nameof(sourceParam));
             ArgAsUnknown = unknownStr;
             ArgKind = CppTemplateArgumentKind.Unknown;
             IsSpecializedArgument = true;
@@ -76,6 +76,43 @@ namespace CppAst
             get => 0;
             set => throw new InvalidOperationException("This type does not support SizeOf");
         }
+
+        /// <summary>
+        /// Checks whether the two template arguments are the same or not
+        /// </summary>
+        public bool Equals(CppTemplateArgument other)
+        {
+            if (ArgKind != other.ArgKind)
+            {
+                return false;
+            }
+
+            if (ArgKind == CppTemplateArgumentKind.AsType)
+            {
+                if (!ArgAsType.Equals(other.ArgAsType))
+                {
+                    return false;
+                }
+            }
+            else if (ArgKind == CppTemplateArgumentKind.AsInteger)
+            {
+                if (ArgAsInteger != other.ArgAsInteger)
+                {
+                    return false;
+                }
+            }
+            else
+            {
+                if (!ArgAsUnknown.Equals(other.ArgAsUnknown))
+                {
+                    return false;
+                }
+            }
+
+            return SourceParam.Equals(other.SourceParam) &&
+              IsSpecializedArgument.Equals(other.IsSpecializedArgument);
+        }
+
 
         /// <inheritdoc />
         public override bool Equals(object obj)

--- a/src/CppAst/CppUnexposedType.cs
+++ b/src/CppAst/CppUnexposedType.cs
@@ -42,6 +42,9 @@ namespace CppAst
         public List<CppType> TemplateParameters { get; }
 
         /// <inheritdoc />
+        public List<CppTemplateArgument> TemplateSpecializedArguments { get; } = new List<CppTemplateArgument>();
+
+        /// <inheritdoc />
         public override bool Equals(object obj)
         {
             return ReferenceEquals(this, obj) || obj is CppTemplateParameterType other && Equals(other);


### PR DESCRIPTION
Currently partial template specialization is not properly handled, which means that in that case both the "TemplateSpecializedArguments" and "TemplateParameters" have to be filled.

It also have to be noted when template specialization is handled, it needs to take care of already specialized parameters in the base, as that implicitly means that the given class has that template parameter also specialized.

E.g.:

template <typename T, int N>
class VectorBase : public virtual std::array<T, N>;

template <typename T>
class Vector2d : public VectorBase<T, 2>;

using Vect2i = Vector2d<int32_t>;

- VectorBase has 2 generic template parameters ("T" and "N")

- Vector2d has 1 generic template parameter ("T") and one specialized one ("N" = 2)

- Vector2i has 2 specialized template parameters ("T" = int and "N" = 2)