### PR TITLE
Fixing partial template specialization

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## 0.8.0-alpha-015 (13 Dec 2023)
+- Fixed partial template specialization
+
 ## 0.8.0-alpha-004 (07 Sep 2022)
 - Fix issue with late predeclaration rewrites filespan (#53)
 

--- a/src/CppAst.Tests/TestMisc.cs
+++ b/src/CppAst.Tests/TestMisc.cs
@@ -50,5 +50,105 @@ private:
                 }
             );
         }
+
+        [Test]
+        public void TestPartialSpecialization()
+        {
+            ParseAssert(@"
+
+template <typename T, int N>
+class ArrayBase
+{
+public:
+  ArrayBase(T array[N]) { for(int i=0;i<N;i++) array_[i] = array_[i]; }
+private:
+  T array_[N];
+};
+
+template <typename T>
+class Array2d : public ArrayBase<T, 2>
+{
+public:
+  using ArrayBase<T,2>::ArrayBase;
+};
+
+using Array2i = Array2d<int>;
+
+#include <array>
+
+template <typename T, int N>
+class VectorBase : public virtual std::array<T, N>
+{
+};
+
+template <typename T>
+class Vector3d : public VectorBase<T, 3>
+{
+public:
+  Vector3d(const std::array<T, 3> & elements = {0, 0, 0})
+      : Vector3d<T>(elements[0], elements[1], elements[2]) {}
+
+  Vector3d(T x, T y, T z)
+  {
+    (*this)[0] = x, (*this)[1] = y; (*this)[2] = z;
+  }
+};
+
+using Vect3i = Vector3d<int32_t>;
+",
+                compilation =>
+                {
+                    Assert.False(compilation.HasErrors);
+                    Assert.AreEqual(6, compilation.Classes.Count);
+
+                    /** Tests whether we are a generic template class with only non-specialized parameters (T,N) */
+                    Assert.AreEqual(CppTemplateKind.TemplateClass, compilation.Classes[0].TemplateKind);
+                    Assert.AreEqual(2, compilation.Classes[0].TemplateParameters.Count);
+                    Assert.AreEqual(0, compilation.Classes[0].TemplateSpecializedArguments.Count);
+                    Assert.AreEqual("T", compilation.Classes[0].TemplateParameters[0].FullName);
+                    Assert.AreEqual("int N", compilation.Classes[0].TemplateParameters[1].FullName);
+
+                    /** Tests whether we are a partially specialized template class with one non-specialized (T) and one specialized parameter (2) */
+                    Assert.AreEqual(CppTemplateKind.PartialTemplateClass, compilation.Classes[1].TemplateKind);
+                    Assert.AreEqual(1, compilation.Classes[1].TemplateParameters.Count);
+                    Assert.AreEqual("T", compilation.Classes[1].TemplateParameters[0].FullName);
+                    Assert.AreEqual(1, compilation.Classes[1].TemplateSpecializedArguments.Count);
+                    Assert.AreEqual(CppTemplateArgumentKind.AsInteger, compilation.Classes[1].TemplateSpecializedArguments[0].ArgKind);
+                    Assert.AreEqual(2, compilation.Classes[1].TemplateSpecializedArguments[0].ArgAsInteger);
+
+                    /** Tests whether we are a fully specialized template class with two specialized parameters (int, 2) */
+                    Assert.AreEqual(CppTemplateKind.TemplateSpecializedClass, compilation.Classes[2].TemplateKind);
+                    Assert.AreEqual(2, compilation.Classes[2].TemplateSpecializedArguments.Count);
+                    Assert.AreEqual(CppTemplateArgumentKind.AsType, compilation.Classes[2].TemplateSpecializedArguments[0].ArgKind);
+                    Assert.AreEqual("int", compilation.Classes[2].TemplateSpecializedArguments[0].ArgAsType.FullName);
+                    Assert.AreEqual(CppTemplateArgumentKind.AsInteger, compilation.Classes[2].TemplateSpecializedArguments[1].ArgKind);
+                    Assert.AreEqual(2, compilation.Classes[2].TemplateSpecializedArguments[1].ArgAsInteger);
+
+                    /** Tests whether we are a generic template class with only non-specialized parameters (T, N) */
+                    Assert.AreEqual(CppTemplateKind.TemplateClass, compilation.Classes[3].TemplateKind);
+                    Assert.AreEqual(2, compilation.Classes[3].TemplateParameters.Count);
+                    Assert.AreEqual(0, compilation.Classes[3].TemplateSpecializedArguments.Count);
+                    Assert.AreEqual("T", compilation.Classes[3].TemplateParameters[0].FullName);
+                    Assert.AreEqual("int N", compilation.Classes[3].TemplateParameters[1].FullName);
+
+                    /** Tests whether we are a partially specialized template class with one non-specialized (T) and one specialized parameter (3) */
+                    Assert.AreEqual(CppTemplateKind.PartialTemplateClass, compilation.Classes[4].TemplateKind);
+                    Assert.AreEqual(1, compilation.Classes[4].TemplateParameters.Count);
+                    Assert.AreEqual("T", compilation.Classes[4].TemplateParameters[0].FullName);
+                    Assert.AreEqual(1, compilation.Classes[4].TemplateSpecializedArguments.Count);
+                    Assert.AreEqual(CppTemplateArgumentKind.AsInteger, compilation.Classes[4].TemplateSpecializedArguments[0].ArgKind);
+                    Assert.AreEqual(3, compilation.Classes[4].TemplateSpecializedArguments[0].ArgAsInteger);
+
+                    /** Tests whether we are a fully specialized template class with two specialized parameters (int,3) */
+                    Assert.AreEqual(CppTemplateKind.TemplateSpecializedClass, compilation.Classes[5].TemplateKind);
+                    Assert.AreEqual(2, compilation.Classes[5].TemplateSpecializedArguments.Count);
+                    Assert.AreEqual(CppTemplateArgumentKind.AsType, compilation.Classes[5].TemplateSpecializedArguments[0].ArgKind);
+                    Assert.AreEqual("int", compilation.Classes[5].TemplateSpecializedArguments[0].ArgAsType.FullName);
+                    Assert.AreEqual(CppTemplateArgumentKind.AsInteger, compilation.Classes[5].TemplateSpecializedArguments[1].ArgKind);
+                    Assert.AreEqual(3, compilation.Classes[5].TemplateSpecializedArguments[1].ArgAsInteger);
+
+                }
+            );
+        }
     }
 }

--- a/src/CppAst.Tests/TestTypes.cs
+++ b/src/CppAst.Tests/TestTypes.cs
@@ -344,11 +344,22 @@ public:
   TemplatedClass2D operator-(const TemplatedClass2D& other) const;
 };
 
+template <typename T>
+class TemplatedClass3D : public virtual TemplatedClass<T, 3>
+{
+public:
+  TemplatedClass3D(T value);
+
+  TemplatedClass3D<T> operator+(const TemplatedClass3D<T>& other) const;
+
+  TemplatedClass3D operator-(const TemplatedClass3D& other) const;
+};
+
 ",
             compilation =>
             {
                 Assert.False(compilation.HasErrors);
-                Assert.AreEqual(compilation.Classes.Count, 2);
+                Assert.AreEqual(compilation.Classes.Count, 3);
                 {
                     var templatedClass = compilation.Classes[0];
                     Assert.AreEqual(templatedClass.Name, "TemplatedClass");
@@ -411,7 +422,7 @@ public:
                     var other2Type = ((other2.Type as CppReferenceType).ElementType as CppQualifiedType).ElementType as CppClass;
                     Assert.AreEqual(other2Type.TemplateKind, CppTemplateKind.TemplateClass);
                     Assert.AreEqual(other2Type.TemplateParameters.Count, 2);
-                    Assert.AreEqual(otherType.TemplateSpecializedArguments.Count, 0);
+                    Assert.AreEqual(other2Type.TemplateSpecializedArguments.Count, 0);
                     Assert.AreEqual(other2Type.Name, "TemplatedClass");
 
                     T = other2Type.TemplateParameters[0];
@@ -429,14 +440,18 @@ public:
                     Assert.AreEqual(templatedClass2D.Name, "TemplatedClass2D");
                     Assert.AreEqual(templatedClass2D.Constructors.Count, 1);
                     Assert.AreEqual(templatedClass2D.Functions.Count, 2);
-                    Assert.AreEqual(templatedClass2D.TemplateKind, CppTemplateKind.TemplateClass);
+                    Assert.AreEqual(templatedClass2D.TemplateKind, CppTemplateKind.PartialTemplateClass);
                     Assert.AreEqual(templatedClass2D.TemplateParameters.Count, 1);
-                    Assert.AreEqual(templatedClass2D.TemplateSpecializedArguments.Count, 0);
+                    Assert.AreEqual(templatedClass2D.TemplateSpecializedArguments.Count, 1);
 
 
                     var T = templatedClass2D.TemplateParameters[0];
                     Assert.True(T is CppTemplateParameterType);
                     Assert.AreEqual((T as CppTemplateParameterType).Name, "T");
+
+                    var N = templatedClass2D.TemplateSpecializedArguments[0];
+                    Assert.AreEqual(N.ArgKind, CppTemplateArgumentKind.AsInteger);
+                    Assert.AreEqual(2, N.ArgAsInteger);
 
                     var baseClass = templatedClass2D.BaseTypes[0].Type as CppClass;
                     Assert.AreEqual(baseClass, compilation.Classes[0]);
@@ -450,14 +465,18 @@ public:
                     Assert.AreEqual(other.Type.TypeKind, CppTypeKind.Reference); // ref
                     Assert.AreEqual((other.Type as CppReferenceType).ElementType.TypeKind, CppTypeKind.Qualified); // const
                     var otherType = ((other.Type as CppReferenceType).ElementType as CppQualifiedType).ElementType as CppClass;
-                    Assert.AreEqual(otherType.TemplateKind, CppTemplateKind.TemplateClass);
+                    Assert.AreEqual(otherType.TemplateKind, CppTemplateKind.PartialTemplateClass);
                     Assert.AreEqual(otherType.TemplateParameters.Count, 1);
-                    Assert.AreEqual(otherType.TemplateSpecializedArguments.Count, 0);
+                    Assert.AreEqual(otherType.TemplateSpecializedArguments.Count, 1);
                     Assert.AreEqual(otherType.Name, "TemplatedClass2D");
 
                     T = otherType.TemplateParameters[0];
                     Assert.True(T is CppTemplateParameterType);
                     Assert.AreEqual((T as CppTemplateParameterType).Name, "T");
+
+                    N = otherType.TemplateSpecializedArguments[0];
+                    Assert.AreEqual(N.ArgKind, CppTemplateArgumentKind.AsInteger);
+                    Assert.AreEqual(2, N.ArgAsInteger);
 
                     var operatorMinus = templatedClass2D.Functions[1];
                     Assert.AreEqual(operatorMinus.Name, "operator-");
@@ -468,16 +487,85 @@ public:
                     Assert.AreEqual(other2.Type.TypeKind, CppTypeKind.Reference); // ref
                     Assert.AreEqual((other2.Type as CppReferenceType).ElementType.TypeKind, CppTypeKind.Qualified); // const
                     var other2Type = ((other2.Type as CppReferenceType).ElementType as CppQualifiedType).ElementType as CppClass;
-                    Assert.AreEqual(other2Type.TemplateKind, CppTemplateKind.TemplateClass);
+                    Assert.AreEqual(other2Type.TemplateKind, CppTemplateKind.PartialTemplateClass);
                     Assert.AreEqual(other2Type.TemplateParameters.Count, 1);
-                    Assert.AreEqual(otherType.TemplateSpecializedArguments.Count, 0);
+                    Assert.AreEqual(other2Type.TemplateSpecializedArguments.Count, 1);
                     Assert.AreEqual(other2Type.Name, "TemplatedClass2D");
 
                     T = other2Type.TemplateParameters[0];
                     Assert.True(T is CppTemplateParameterType);
                     Assert.AreEqual((T as CppTemplateParameterType).Name, "T");
 
+                    N = other2Type.TemplateSpecializedArguments[0];
+                    Assert.AreEqual(N.ArgKind, CppTemplateArgumentKind.AsInteger);
+                    Assert.AreEqual(2, N.ArgAsInteger);
                 }
+
+                {
+                    var templatedClass3D = compilation.Classes[2];
+                    Assert.AreEqual(templatedClass3D.Name, "TemplatedClass3D");
+                    Assert.AreEqual(templatedClass3D.Constructors.Count, 1);
+                    Assert.AreEqual(templatedClass3D.Functions.Count, 2);
+                    Assert.AreEqual(templatedClass3D.TemplateKind, CppTemplateKind.PartialTemplateClass);
+                    Assert.AreEqual(templatedClass3D.TemplateParameters.Count, 1);
+                    Assert.AreEqual(templatedClass3D.TemplateSpecializedArguments.Count, 1);
+
+                    var T = templatedClass3D.TemplateParameters[0];
+                    Assert.True(T is CppTemplateParameterType);
+                    Assert.AreEqual((T as CppTemplateParameterType).Name, "T");
+
+                    var N = templatedClass3D.TemplateSpecializedArguments[0];
+                    Assert.AreEqual(N.ArgKind, CppTemplateArgumentKind.AsInteger);
+                    Assert.AreEqual(3, N.ArgAsInteger);
+
+                    var baseClass = templatedClass3D.BaseTypes[0].Type as CppClass;
+                    Assert.AreEqual(baseClass, compilation.Classes[0]);
+
+                    var operatorPlus = templatedClass3D.Functions[0];
+                    Assert.AreEqual(operatorPlus.Name, "operator+");
+
+                    Assert.AreEqual(operatorPlus.Parameters.Count, 1);
+                    var other = operatorPlus.Parameters[0];
+                    Assert.AreEqual(other.Name, "other");
+                    Assert.AreEqual(other.Type.TypeKind, CppTypeKind.Reference); // ref
+                    Assert.AreEqual((other.Type as CppReferenceType).ElementType.TypeKind, CppTypeKind.Qualified); // const
+                    var otherType = ((other.Type as CppReferenceType).ElementType as CppQualifiedType).ElementType as CppClass;
+                    Assert.AreEqual(otherType.TemplateKind, CppTemplateKind.PartialTemplateClass);
+                    Assert.AreEqual(otherType.TemplateParameters.Count, 1);
+                    Assert.AreEqual(otherType.TemplateSpecializedArguments.Count, 1);
+                    Assert.AreEqual(otherType.Name, "TemplatedClass3D");
+
+                    T = otherType.TemplateParameters[0];
+                    Assert.True(T is CppTemplateParameterType);
+                    Assert.AreEqual((T as CppTemplateParameterType).Name, "T");
+
+                    N = otherType.TemplateSpecializedArguments[0];
+                    Assert.AreEqual(N.ArgKind, CppTemplateArgumentKind.AsInteger);
+                    Assert.AreEqual(3, N.ArgAsInteger);
+
+                    var operatorMinus = templatedClass3D.Functions[1];
+                    Assert.AreEqual(operatorMinus.Name, "operator-");
+
+                    Assert.AreEqual(operatorMinus.Parameters.Count, 1);
+                    var other2 = operatorMinus.Parameters[0];
+                    Assert.AreEqual(other2.Name, "other");
+                    Assert.AreEqual(other2.Type.TypeKind, CppTypeKind.Reference); // ref
+                    Assert.AreEqual((other2.Type as CppReferenceType).ElementType.TypeKind, CppTypeKind.Qualified); // const
+                    var other2Type = ((other2.Type as CppReferenceType).ElementType as CppQualifiedType).ElementType as CppClass;
+                    Assert.AreEqual(other2Type.TemplateKind, CppTemplateKind.PartialTemplateClass);
+                    Assert.AreEqual(other2Type.TemplateParameters.Count, 1);
+                    Assert.AreEqual(other2Type.TemplateSpecializedArguments.Count, 1);
+                    Assert.AreEqual(other2Type.Name, "TemplatedClass3D");
+
+                    T = other2Type.TemplateParameters[0];
+                    Assert.True(T is CppTemplateParameterType);
+                    Assert.AreEqual((T as CppTemplateParameterType).Name, "T");
+
+                    N = other2Type.TemplateSpecializedArguments[0];
+                    Assert.AreEqual(N.ArgKind, CppTemplateArgumentKind.AsInteger);
+                    Assert.AreEqual(3, N.ArgAsInteger);
+                }
+
             });
 
 

--- a/src/CppAst/CppAst.csproj
+++ b/src/CppAst/CppAst.csproj
@@ -3,7 +3,7 @@
     <TargetFrameworks>net6.0</TargetFrameworks>
     <VersionPrefix>0.8.0</VersionPrefix>
     <VersionSuffix>alpha</VersionSuffix>
-    <BuildNumber>014</BuildNumber>
+    <BuildNumber>015</BuildNumber>
     <PackageId>CppAst.cgnx</PackageId>
     <Description>CppAst is a .NET library providing a C/C++ parser for header files with access to the full AST, comments and macros</Description>
     <Copyright>Alexandre Mutel</Copyright>
@@ -26,7 +26,7 @@
     <PublishRepositoryUrl>true</PublishRepositoryUrl>
     <IncludeSymbols>true</IncludeSymbols>
     <SymbolPackageFormat>snupkg</SymbolPackageFormat>
-    <Version>0.8.0-alpha-014</Version>
+    <Version>0.8.0-alpha-015</Version>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/CppAst/CppBaseType.cs
+++ b/src/CppAst/CppBaseType.cs
@@ -3,6 +3,7 @@
 // See license.txt file in the project root for full license information.
 
 using System;
+using System.Collections.Generic;
 using System.Text;
 
 namespace CppAst
@@ -35,6 +36,11 @@ namespace CppAst
         /// Gets the C++ type associated.
         /// </summary>
         public CppType Type { get; }
+
+        /// <summary>
+        /// Specialized template parameters for the given instance of the base type
+        /// </summary>
+        public List<CppTemplateArgument> TemplateSpecializedArguments { get; } = new List<CppTemplateArgument>();
 
         /// <inheritdoc />
         public override string ToString()

--- a/src/CppAst/CppModelBuilder.cs
+++ b/src/CppAst/CppModelBuilder.cs
@@ -10,6 +10,7 @@ using System.Text;
 using System.Runtime.InteropServices;
 using ClangSharp;
 using ClangSharp.Interop;
+using System.Linq;
 
 namespace CppAst
 {
@@ -84,6 +85,66 @@ namespace CppAst
 
             return null;
         }
+
+
+        /*
+         * Helper function to add specialized template parameters from a given source to a destination parameter list
+         * It also takes care of the fact that libClang can return the same template parameter 'a bit differently' 
+         * depending on where it is being used
+         */
+        private void AddTemplateSpecializedArguments(List<CppTemplateArgument> sourceArguments, List<CppTemplateArgument> destinationArguments)
+        {
+            foreach (var p in sourceArguments)
+            {
+                if (!destinationArguments.Contains(p))
+                {
+                    /** 
+                     * Ok, BaseTypes is a strange beast. 
+                     * We might landed here because we are trying to set the same template
+                     * parameter (e.g. 'N') multiple times. And we are trying to set the 
+                     * same parameter to different value (as we passed contains, which means that
+                     * the parameters are different).
+                     * This might sound strange, but there is an explanation to that.
+                     * libClang might return the same template parameter differently depending on
+                     * what layer it is being parsed at, e.g. once you might receive a "B = int",
+                     * but at the second time you might receive a "B = type-parameter-0-0".
+                     * So we need to make sure that if we are setting the same parameter,
+                     * we are changing a not specialized parameter to a specialized one.
+                     */
+                    var existingParams = destinationArguments.Where(param => param.SourceParam.FullName.Equals(p.SourceParam.FullName)).ToList();
+                    if (existingParams.Count() == 0)
+                    {
+                        destinationArguments.Add(p);
+                    }
+                    else
+                    {
+                        /* This is quite impossible, just to make sure */
+                        if (existingParams.Count() > 1)
+                        {
+                            throw new InvalidOperationException($"The same template parameter `{p.SourceParam.FullName}` exists more than one times");
+                        }
+                        var existingParam = existingParams[0];
+                        if (!existingParam.IsSpecializedArgument && p.IsSpecializedArgument)
+                        {
+                            /* We need to replace the already existing non-specialized parameter with the new specialized one */
+                            var index = destinationArguments.IndexOf(existingParam);
+                            destinationArguments[index] = p;
+                        }
+                    }
+                }
+            }
+        }
+
+
+        private void UpdateTemplateType(CppClass cppClass)
+        {
+            /* If we have both generic and specialized template classes, we are partial */
+            if (cppClass.TemplateKind == CppTemplateKind.TemplateClass && cppClass.TemplateParameters.Count > 0 && cppClass.TemplateSpecializedArguments.Count > 0)
+            {
+                cppClass.TemplateKind = CppTemplateKind.PartialTemplateClass;
+            }
+        }
+
 
         private CppContainerContext GetOrCreateDeclarationContainer(CXCursor cursor, void* data)
         {
@@ -169,6 +230,12 @@ namespace CppAst
                             }
                             return CXChildVisitResult.CXChildVisit_Continue;
                         }, new CXClientData((IntPtr)data));
+
+                        /* Inherit already specialized template parameters, even though this is a template class itself */
+                        foreach (var b in cppClass.BaseTypes)
+                        {
+                            AddTemplateSpecializedArguments(b.TemplateSpecializedArguments, cppClass.TemplateSpecializedArguments);
+                        }
                     }
                     else if (cursor.DeclKind == CX_DeclKind.CX_DeclKind_ClassTemplateSpecialization
                         || cursor.DeclKind == CX_DeclKind.CX_DeclKind_ClassTemplatePartialSpecialization)
@@ -235,11 +302,25 @@ namespace CppAst
                                     break;
                             }
                         }
+
+                        /* We explicitly inherit the specialized arguments as well */
+                        if (cppClass.PrimaryTemplate.TemplateSpecializedArguments.Count > 0)
+                        {
+                            AddTemplateSpecializedArguments(cppClass.PrimaryTemplate.TemplateSpecializedArguments, cppClass.TemplateSpecializedArguments);
+                        }
+
+                        /* Do the same for all base types as well, that might have specialized template arguments */
+                        foreach (var b in cppClass.PrimaryTemplate.BaseTypes)
+                        {
+                            AddTemplateSpecializedArguments(b.TemplateSpecializedArguments, cppClass.TemplateSpecializedArguments);
+                        }
                     }
                     else
                     {
                         cppClass.TemplateKind = CppTemplateKind.NormalClass;
                     }
+
+                    UpdateTemplateType(cppClass);
 
                     defaultContainerVisibility = cursor.Kind == CXCursorKind.CXCursor_ClassDecl ? CppVisibility.Private : CppVisibility.Public;
                     break;
@@ -369,9 +450,16 @@ namespace CppAst
                     {
                         bool isAnonymous = cursor.IsAnonymous;
                         var cppClass = VisitClassDecl(cursor, data);
+                        // Make sure to bubble up the specialized template parameters from all the base types
+                        foreach (var b in cppClass.BaseTypes)
+                        {
+                            AddTemplateSpecializedArguments(b.TemplateSpecializedArguments, cppClass.TemplateSpecializedArguments);
+                        }
+                        UpdateTemplateType(cppClass);
                         // Empty struct/class/union declaration are considered as fields
                         if (isAnonymous)
                         {
+                            cppClass.Name = string.Empty;
                             Debug.Assert(string.IsNullOrEmpty(cppClass.Name));
                             var containerContext = GetOrCreateDeclarationContainer(parent, data);
 
@@ -436,11 +524,37 @@ namespace CppAst
                     {
                         var cppClass = (CppClass)GetOrCreateDeclarationContainer(parent, data).Container;
                         var baseType = GetCppType(cursor.Type.Declaration, cursor.Type, cursor, data);
+
+                        /** This is kind of a hack to get the specialized template arguments */
+                        CXCursor paramCursor;
+                        CXType paramCursorType;
+                        if (cursor.Type.kind == CXTypeKind.CXType_Elaborated)
+                        {
+                            paramCursor = cursor.Type.CanonicalType.Declaration;
+                            paramCursorType = cursor.Type.CanonicalType;
+                        }
+                        else
+                        {
+                            paramCursor = cursor.Type.Declaration;
+                            paramCursorType = cursor.Type;
+                        }
+                        var (_, templateSpecializedArguments) = ParseTemplateArgumentsAndParameters(paramCursor, paramCursorType, new CXClientData((IntPtr)data));
                         var cppBaseType = new CppBaseType(baseType)
                         {
                             Visibility = GetVisibility(cursor.CXXAccessSpecifier),
                             IsVirtual = cursor.IsVirtualBase
                         };
+
+                        /*
+                         * Even though this is a base type, it can be a specialized template one which we
+                         * need to keep track of, so that "consumers" of this type might inherit the
+                         * specialized template parameters automatically.
+                         */
+                        if (templateSpecializedArguments != null && templateSpecializedArguments.Count > 0)
+                        {
+                            cppBaseType.TemplateSpecializedArguments.AddRange(templateSpecializedArguments);
+                        }
+
                         cppClass.BaseTypes.Add(cppBaseType);
                         break;
                     }
@@ -1888,16 +2002,22 @@ namespace CppAst
                         {
                             type = type.InjectedSpecializationType;
                         }
+
                         if (type.Declaration.Kind == CXCursorKind.CXCursor_ClassTemplate
                         || type.Declaration.Kind == CXCursorKind.CXCursor_ClassTemplatePartialSpecialization)
                         {
                             return VisitClassDecl(type.Declaration, data);
                         }
                         var cppUnexposedType = new CppUnexposedType(type.ToString()) { SizeOf = (int)type.SizeOf };
-                        var templateParameters = ParseTemplateSpecializedArguments(cursor, type, new CXClientData((IntPtr)data));
-                        if (templateParameters != null)
+                        var (templateParameters, templateSpecializedArguments) = ParseTemplateArgumentsAndParameters(cursor, type, new CXClientData((IntPtr)data));
+                        if (templateParameters != null && templateParameters.Count > 0)
                         {
                             cppUnexposedType.TemplateParameters.AddRange(templateParameters);
+                        }
+
+                        if (templateSpecializedArguments != null && templateSpecializedArguments.Count > 0)
+                        {
+                            AddTemplateSpecializedArguments(templateSpecializedArguments, cppUnexposedType.TemplateSpecializedArguments);
                         }
                         return cppUnexposedType;
                     }
@@ -1975,41 +2095,89 @@ namespace CppAst
             RootCompilation.Diagnostics.Warning($"Unhandled declaration: {cursor.Kind}/{cursor} in {parent}.", cppLocation);
         }
 
-        private List<CppType> ParseTemplateSpecializedArguments(CXCursor cursor, CXType type, CXClientData data)
+        private (List<CppType>, List<CppTemplateArgument>) ParseTemplateArgumentsAndParameters(CXCursor cursor, CXType type, CXClientData data)
         {
             var numTemplateArguments = type.NumTemplateArguments;
-            if (numTemplateArguments < 0) return null;
-
+            if (numTemplateArguments < 0) return (null, null);
+ 
             var templateCppTypes = new List<CppType>();
+            var specializedTemplateCppTypes = new List<CppTemplateArgument>();
+
             for (var templateIndex = 0; templateIndex < numTemplateArguments; ++templateIndex)
             {
                 var templateArg = type.GetTemplateArgument((uint)templateIndex);
-
                 switch (templateArg.kind)
                 {
                     case CXTemplateArgumentKind.CXTemplateArgumentKind_Type:
-                        var templateArgType = templateArg.AsType;
-                        //var templateArg = type.GetTemplateArgumentAsType((uint)templateIndex);
-                        var templateCppType = GetCppType(templateArgType.Declaration, templateArgType, cursor, data);
-                        templateCppTypes.Add(templateCppType);
+                        {
+                            var templateArgType = templateArg.AsType;
+                            var templateCppType = GetCppType(templateArgType.Declaration, templateArgType, cursor, data);
+                            templateCppTypes.Add(templateCppType);
+                        }
                         break;
+
+                    case CXTemplateArgumentKind.CXTemplateArgumentKind_Integral:
+                        {
+                            var value = templateArg.AsIntegral;
+                            var templateParam = TryToCreateTemplateParameters(cursor.GetTemplateParameter(0, (uint)templateIndex), data) as CppTemplateParameterNonType;
+                            if (templateParam != null)
+                            {
+                                var templateCppType = new CppTemplateParameterType(templateParam.Name);
+                                specializedTemplateCppTypes.Add(new CppTemplateArgument(templateCppType, value));
+                            }
+                        }
+                        break;
+
+                    case CXTemplateArgumentKind.CXTemplateArgumentKind_Expression:
+                        {
+                            var expression = VisitExpression(templateArg.AsExpr, data);
+                            if (expression.Kind == CppExpressionKind.IntegerLiteral)
+                            {
+                                var templateParam = TryToCreateTemplateParameters(cursor.GetTemplateParameter(0, (uint)templateIndex), data) as CppTemplateParameterNonType;
+                                if (templateParam != null)
+                                {
+                                    var templateCppType = new CppTemplateParameterType(templateParam.Name);
+                                    var literal = expression as CppLiteralExpression;
+                                    specializedTemplateCppTypes.Add(new CppTemplateArgument(templateCppType, Int32.Parse(literal.Value)));
+                                }
+                            }
+                            else if (expression.Kind == CppExpressionKind.Unexposed)
+                            {
+                                var templateParam = TryToCreateTemplateParameters(cursor.GetTemplateParameter(0, (uint)templateIndex), data) as CppTemplateParameterNonType;
+                                if (templateParam != null)
+                                {
+                                    var templateCppType = new CppTemplateParameterType(templateParam.Name);
+                                    var raw = expression as CppRawExpression;
+                                    Int32 argument;
+                                    var isInteger = Int32.TryParse(raw.Text, out argument);
+                                    /* 
+                                     * We are only using unexposed template parameters that are integers actually.
+                                     * As raw strings we'd get (again) 'size_t N' or other compile time expressions - which we
+                                     * are not really interested in
+                                     */
+
+                                    if (isInteger)
+                                    {
+                                        specializedTemplateCppTypes.Add(new CppTemplateArgument(templateCppType, argument));
+                                    }
+                                }
+                            }
+                        }
+                        break;
+
                     case CXTemplateArgumentKind.CXTemplateArgumentKind_Null:
                     case CXTemplateArgumentKind.CXTemplateArgumentKind_Declaration:
                     case CXTemplateArgumentKind.CXTemplateArgumentKind_NullPtr:
-                    case CXTemplateArgumentKind.CXTemplateArgumentKind_Integral:
                     case CXTemplateArgumentKind.CXTemplateArgumentKind_Template:
                     case CXTemplateArgumentKind.CXTemplateArgumentKind_TemplateExpansion:
-                    case CXTemplateArgumentKind.CXTemplateArgumentKind_Expression:
                     case CXTemplateArgumentKind.CXTemplateArgumentKind_Pack:
                     case CXTemplateArgumentKind.CXTemplateArgumentKind_Invalid:
                         break;
-                    default:
-                        throw new ArgumentOutOfRangeException();
                 }
             }
-
-            return templateCppTypes;
-        }
+ 
+            return (templateCppTypes, specializedTemplateCppTypes);
+         }
 
         private class CppContainerContext
         {

--- a/src/CppAst/CppTemplateArgument.cs
+++ b/src/CppAst/CppTemplateArgument.cs
@@ -22,15 +22,15 @@ namespace CppAst
 
         public CppTemplateArgument(CppType sourceParam, long intArg) : base(CppTypeKind.TemplateArgumentType)
         {
-			SourceParam = sourceParam ?? throw new ArgumentNullException(nameof(sourceParam));
+            SourceParam = sourceParam ?? throw new ArgumentNullException(nameof(sourceParam));
             ArgAsInteger = intArg;
             ArgKind = CppTemplateArgumentKind.AsInteger;
             IsSpecializedArgument = true;
         }
 
-		public CppTemplateArgument(CppType sourceParam, string unknownStr) : base(CppTypeKind.TemplateArgumentType)
+        public CppTemplateArgument(CppType sourceParam, string unknownStr) : base(CppTypeKind.TemplateArgumentType)
         {
-			SourceParam = sourceParam ?? throw new ArgumentNullException(nameof(sourceParam));
+            SourceParam = sourceParam ?? throw new ArgumentNullException(nameof(sourceParam));
             ArgAsUnknown = unknownStr;
             ArgKind = CppTemplateArgumentKind.Unknown;
             IsSpecializedArgument = true;
@@ -76,6 +76,43 @@ namespace CppAst
             get => 0;
             set => throw new InvalidOperationException("This type does not support SizeOf");
         }
+
+        /// <summary>
+        /// Checks whether the two template arguments are the same or not
+        /// </summary>
+        public bool Equals(CppTemplateArgument other)
+        {
+            if (ArgKind != other.ArgKind)
+            {
+                return false;
+            }
+
+            if (ArgKind == CppTemplateArgumentKind.AsType)
+            {
+                if (!ArgAsType.Equals(other.ArgAsType))
+                {
+                    return false;
+                }
+            }
+            else if (ArgKind == CppTemplateArgumentKind.AsInteger)
+            {
+                if (ArgAsInteger != other.ArgAsInteger)
+                {
+                    return false;
+                }
+            }
+            else
+            {
+                if (!ArgAsUnknown.Equals(other.ArgAsUnknown))
+                {
+                    return false;
+                }
+            }
+
+            return SourceParam.Equals(other.SourceParam) &&
+              IsSpecializedArgument.Equals(other.IsSpecializedArgument);
+        }
+
 
         /// <inheritdoc />
         public override bool Equals(object obj)

--- a/src/CppAst/CppUnexposedType.cs
+++ b/src/CppAst/CppUnexposedType.cs
@@ -42,6 +42,9 @@ namespace CppAst
         public List<CppType> TemplateParameters { get; }
 
         /// <inheritdoc />
+        public List<CppTemplateArgument> TemplateSpecializedArguments { get; } = new List<CppTemplateArgument>();
+
+        /// <inheritdoc />
         public override bool Equals(object obj)
         {
             return ReferenceEquals(this, obj) || obj is CppTemplateParameterType other && Equals(other);


### PR DESCRIPTION
Currently partial template specialization is not properly handled, which means that in that case both the "TemplateSpecializedArguments" and "TemplateParameters" have to be filled.

It also have to be noted when template specialization is handled, it needs to take care of already specialized parameters in the base, as that implicitly means that the given class has that template parameter also specialized.

E.g.:

template <typename T, int N>
class VectorBase : public virtual std::array<T, N>;

template <typename T>
class Vector2d : public VectorBase<T, 2>;

using Vect2i = Vector2d<int32_t>;

- VectorBase has 2 generic template parameters ("T" and "N")

- Vector2d has 1 generic template parameter ("T") and one specialized one ("N" = 2)

- Vector2i has 2 specialized template parameters ("T" = int and "N" = 2)