### PR TITLE
Return type 'auto' is not exposed by CppAst

### DIFF
--- a/src/CppAst.Tests/TestMisc.cs
+++ b/src/CppAst.Tests/TestMisc.cs
@@ -50,5 +50,39 @@ private:
                 }
             );
         }
+
+        [Test]
+        public void TestAuto()
+        {
+            ParseAssert(@"
+
+class Foo
+{
+public:
+  Foo(int foo) : foo_{foo} {}
+  const auto & foo() const { return foo_; }
+private:
+  int foo_{0};
+};
+
+class Bar
+{
+public:
+  auto Get42() const { return Foo(42); }
+};
+",
+                compilation =>
+                {
+                    Assert.False(compilation.HasErrors);
+                    Assert.AreEqual(2, compilation.Classes.Count);
+                    Assert.AreEqual(1, compilation.Classes[0].Functions.Count);
+                    Assert.AreEqual(CppTypeKind.Reference, compilation.Classes[0].Functions[0].ReturnType.TypeKind);
+                    Assert.AreEqual("const int&", (compilation.Classes[0].Functions[0].ReturnType as CppReferenceType).GetCanonicalType().ToString());
+                    Assert.AreEqual(1, compilation.Classes[1].Functions.Count);
+                    Assert.AreEqual(CppTypeKind.StructOrClass, compilation.Classes[1].Functions[0].ReturnType.TypeKind);
+                    Assert.AreEqual("Foo", (compilation.Classes[1].Functions[0].ReturnType as CppClass).Name);
+                }
+            );
+        }
     }
 }

--- a/src/CppAst/CppModelBuilder.cs
+++ b/src/CppAst/CppModelBuilder.cs
@@ -1905,6 +1905,18 @@ namespace CppAst
                 case CXTypeKind.CXType_Attributed:
                     return GetCppType(type.ModifiedType.Declaration, type.ModifiedType, parent, data);
 
+                case CXTypeKind.CXType_Auto:
+                    {
+                        // If auto is resolved to auto, disregard it
+                        if (type.CanonicalType.kind != CXTypeKind.CXType_Auto)
+                        {
+                            return VisitElaboratedDecl(cursor, type, parent, data);
+                        }
+
+                        WarningUnhandled(cursor, parent, type);
+                        return new CppUnexposedType(type.ToString()) { SizeOf = (int)type.SizeOf };
+                    }
+
                 default:
                     {
                         WarningUnhandled(cursor, parent, type);


### PR DESCRIPTION
So that Bindr can pick up deduced auto type, CppAst needs to support it. This PR adds support for handling deduced auto types