### PR TITLE
Template parameter resolution is not working properly

### DIFF
--- a/src/CppAst.Tests/TestMisc.cs
+++ b/src/CppAst.Tests/TestMisc.cs
@@ -6,7 +6,7 @@ namespace CppAst.Tests
     public class TestMisc : InlineTestBase
     {
         [Test]
-        public void TestMiscFeatures()
+        public void TestUsing()
         {
             ParseAssert(@"
 
@@ -84,5 +84,166 @@ public:
                 }
             );
         }
+
+        [Test]
+        public void TestTemplate()
+        {
+            var options = new CppParserOptions();
+            options.AdditionalArguments.Add("-std=c++17");
+            ParseAssert(@"
+
+#include <memory>
+#include <variant>
+
+template<typename DataType, typename Variant1, typename Variant2, typename Variant3>
+class Foo
+{
+public:
+  Foo(const std::shared_ptr<DataType> & foo) : foo_{foo} {}
+  Foo(const std::variant<Variant1, Variant2, Variant3> & bar) : bar_{bar} {}
+private:
+  std::shared_ptr<DataType> foo_;
+  std::variant<Variant1, Variant2, Variant3> bar_;
+};
+
+using FooInt = Foo<int, double, char, long>;
+",
+                compilation =>
+                {
+                    Assert.False(compilation.HasErrors);
+                    Assert.AreEqual(2, compilation.Classes.Count);
+                    Assert.AreEqual(2, compilation.Classes[0].Constructors.Count);
+                    Assert.AreEqual(1, compilation.Classes[0].Constructors[0].Parameters.Count);
+                    Assert.AreEqual("foo", compilation.Classes[0].Constructors[0].Parameters[0].Name );
+                    Assert.AreEqual(CppTypeKind.Reference, compilation.Classes[0].Constructors[0].Parameters[0].Type.TypeKind);
+                    Assert.AreEqual(CppTypeKind.Qualified, (compilation.Classes[0].Constructors[0].Parameters[0].Type as CppReferenceType).ElementType.TypeKind);
+                    Assert.AreEqual(CppTypeKind.StructOrClass, ((compilation.Classes[0].Constructors[0].Parameters[0].Type as CppReferenceType).ElementType as CppQualifiedType).ElementType.TypeKind);
+                    var clazz = (((compilation.Classes[0].Constructors[0].Parameters[0].Type as CppReferenceType).ElementType as CppQualifiedType).ElementType as CppClass);
+                    Assert.AreEqual(CppTemplateKind.TemplateClass, clazz.TemplateKind);
+                    Assert.AreEqual(1, clazz.TemplateArguments.Count);
+                    Assert.AreEqual(1, clazz.TemplateParameters.Count);
+                    // Don't check the actual shared_ptr<T>'s name, it differs on Windows and on Linux, just make sure the same being mapped
+                    Assert.AreEqual(clazz.TemplateArguments[0].SourceParam.FullName, clazz.TemplateParameters[0].FullName);
+                    Assert.AreEqual(CppTemplateArgumentKind.AsType, clazz.TemplateArguments[0].ArgKind);
+                    Assert.AreEqual("DataType", clazz.TemplateArguments[0].ArgAsType.FullName);
+
+                    Assert.AreEqual(4, compilation.Classes[1].TemplateArguments.Count);
+                    Assert.AreEqual(CppTemplateArgumentKind.AsType, compilation.Classes[1].TemplateArguments[0].ArgKind);
+                    Assert.AreEqual("DataType", compilation.Classes[1].TemplateArguments[0].SourceParam.FullName);
+                    Assert.AreEqual("int", compilation.Classes[1].TemplateArguments[0].ArgAsType.FullName);
+                    Assert.AreEqual("Variant1", compilation.Classes[1].TemplateArguments[1].SourceParam.FullName);
+                    Assert.AreEqual("double", compilation.Classes[1].TemplateArguments[1].ArgAsType.FullName);
+                    Assert.AreEqual("Variant2", compilation.Classes[1].TemplateArguments[2].SourceParam.FullName);
+                    Assert.AreEqual("char", compilation.Classes[1].TemplateArguments[2].ArgAsType.FullName);
+                    Assert.AreEqual("Variant3", compilation.Classes[1].TemplateArguments[3].SourceParam.FullName);
+                    Assert.AreEqual("int", compilation.Classes[1].TemplateArguments[3].ArgAsType.FullName);
+                    Assert.AreEqual(4, compilation.Classes[1].TemplateParameters.Count);
+                    Assert.AreEqual("DataType", compilation.Classes[1].TemplateParameters[0].FullName);
+                    Assert.AreEqual("Variant1", compilation.Classes[1].TemplateParameters[1].FullName);
+                    Assert.AreEqual("Variant2", compilation.Classes[1].TemplateParameters[2].FullName);
+                    Assert.AreEqual("Variant3", compilation.Classes[1].TemplateParameters[3].FullName);
+                }, options
+            );
+        }
+
+        [Test]
+        public void TestStdVariadicTemplate()
+        {
+            var options = new CppParserOptions();
+            options.AdditionalArguments.Add("-std=c++17");
+            ParseAssert(@"
+#include <variant>
+
+void function1(std::variant<float, short, std::variant<double, char>> input);
+void function2(std::tuple<std::variant<float, short>, char, int, std::variant<char, double, long>> input);
+",
+            compilation =>
+            {
+                Assert.False(compilation.HasErrors);
+                Assert.AreEqual(2, compilation.Functions.Count);
+                var function = compilation.Functions[0];
+                Assert.AreEqual(1, function.Parameters.Count);
+                var parameter = function.Parameters[0];
+                Assert.True(parameter.Type is CppClass);
+                Assert.AreEqual(parameter.Name, "input");
+                var parameterClass = parameter.Type as CppClass;
+                Assert.AreEqual(CppTemplateKind.TemplateSpecializedClass, parameterClass.TemplateKind);
+                Assert.AreEqual("variant", parameterClass.Name);
+                Assert.AreEqual(1, parameterClass.TemplateParameters.Count);
+                Assert.AreEqual(3, parameterClass.TemplateArguments.Count);
+                Assert.AreEqual("float", parameterClass.TemplateArguments[0].ArgAsType.FullName);
+                Assert.AreEqual("short", parameterClass.TemplateArguments[1].ArgAsType.FullName);
+                var paramVariant = parameterClass.TemplateArguments[2].ArgAsType as CppClass;
+                Assert.AreEqual(CppTemplateKind.TemplateSpecializedClass, paramVariant.TemplateKind);
+                Assert.AreEqual("variant", paramVariant.Name);
+                Assert.AreEqual(1, paramVariant.TemplateParameters.Count);
+                Assert.AreEqual(2, paramVariant.TemplateArguments.Count);
+                Assert.AreEqual("double", paramVariant.TemplateArguments[0].ArgAsType.FullName);
+                Assert.AreEqual("char", paramVariant.TemplateArguments[1].ArgAsType.FullName);
+
+                function = compilation.Functions[1];
+                Assert.AreEqual(1, function.Parameters.Count);
+                parameter = function.Parameters[0];
+                Assert.True(parameter.Type is CppClass);
+                Assert.AreEqual("input", parameter.Name);
+                parameterClass = parameter.Type as CppClass;
+                Assert.AreEqual(CppTemplateKind.TemplateSpecializedClass, parameterClass.TemplateKind);
+                Assert.AreEqual("tuple", parameterClass.Name);
+                Assert.AreEqual(4, parameterClass.TemplateArguments.Count);
+                paramVariant = parameterClass.TemplateArguments[0].ArgAsType as CppClass;
+                Assert.AreEqual(CppTemplateKind.TemplateSpecializedClass, paramVariant.TemplateKind);
+                Assert.AreEqual("variant", paramVariant.Name);
+                Assert.AreEqual(1, paramVariant.TemplateParameters.Count);
+                Assert.AreEqual(2, paramVariant.TemplateArguments.Count);
+                Assert.AreEqual("float", paramVariant.TemplateArguments[0].ArgAsType.FullName);
+                Assert.AreEqual("short", paramVariant.TemplateArguments[1].ArgAsType.FullName);
+                Assert.AreEqual("char", parameterClass.TemplateArguments[1].ArgAsType.FullName);
+                Assert.AreEqual("int", parameterClass.TemplateArguments[2].ArgAsType.FullName);
+                paramVariant = parameterClass.TemplateArguments[3].ArgAsType as CppClass;
+                Assert.AreEqual(CppTemplateKind.TemplateSpecializedClass, paramVariant.TemplateKind);
+                Assert.AreEqual("variant", paramVariant.Name);
+                Assert.AreEqual(1, paramVariant.TemplateParameters.Count);
+                Assert.AreEqual(3, paramVariant.TemplateArguments.Count);
+                Assert.AreEqual("char", paramVariant.TemplateArguments[0].ArgAsType.FullName);
+                Assert.AreEqual("double", paramVariant.TemplateArguments[1].ArgAsType.FullName);
+                Assert.AreEqual("int", paramVariant.TemplateArguments[2].ArgAsType.FullName);
+            }, options);
+        }
+
+        [Test]
+        public void TestUnderlyingType()
+        {
+            ParseAssert(@"
+#include <type_traits>
+
+enum class OneTwoThree : int16_t
+{
+  One = 1,
+  Two,
+  Three
+};
+typedef std::underlying_type<OneTwoThree>::type OneTwoThreeType;
+
+void function1(const OneTwoThreeType& testEnumType);
+",
+                compilation =>
+                {
+                    Assert.False(compilation.HasErrors);
+                    Assert.AreEqual(1, compilation.Functions.Count);
+                    var function = compilation.Functions[0];
+                    Assert.AreEqual(1, function.Parameters.Count);
+                    Assert.True(function.Parameters[0].Type is CppReferenceType);
+                    var referenceType = function.Parameters[0].Type as CppReferenceType;
+                    Assert.True(referenceType.ElementType is CppQualifiedType);
+                    var qualifiedType = referenceType.ElementType as CppQualifiedType;
+                    Assert.True(qualifiedType.ElementType is CppTypedef);
+                    var typedefType = qualifiedType.ElementType as CppTypedef;
+                    Assert.True(typedefType.ElementType is CppPrimitiveType);
+                    var primitiveType = typedefType.ElementType as CppPrimitiveType;
+                    Assert.AreEqual("short", primitiveType.FullName);
+                }
+            );
+        }
+
     }
 }

--- a/src/CppAst.Tests/TestTypes.cs
+++ b/src/CppAst.Tests/TestTypes.cs
@@ -83,9 +83,9 @@ TemplateStruct<int, Struct2> unexposed;
                     var exposed = compilation.Fields[0].Type as CppClass;
                     Assert.AreEqual("TemplateStruct", exposed.Name);
                     Assert.AreEqual(2, exposed.TemplateParameters.Count);
-                    Assert.AreEqual(CppTemplateArgumentKind.AsType, exposed.TemplateSpecializedArguments[0]?.ArgKind);
-                    Assert.AreEqual(CppPrimitiveKind.Int, (exposed.TemplateSpecializedArguments[0]?.ArgAsType as CppPrimitiveType).Kind);
-                    Assert.AreEqual("Struct2", (exposed.TemplateSpecializedArguments[1].ArgAsType as CppClass)?.Name);
+                    Assert.AreEqual(CppTemplateArgumentKind.AsType, exposed.TemplateArguments[0]?.ArgKind);
+                    Assert.AreEqual(CppPrimitiveKind.Int, (exposed.TemplateArguments[0]?.ArgAsType as CppPrimitiveType).Kind);
+                    Assert.AreEqual("Struct2", (exposed.TemplateArguments[1].ArgAsType as CppClass)?.Name);
 
                     var specialized = exposed.PrimaryTemplate;
                     Assert.AreEqual("TemplateStruct", specialized.Name);
@@ -98,9 +98,9 @@ TemplateStruct<int, Struct2> unexposed;
                     var unexposed = compilation.Fields[1].Type as CppClass;
                     Assert.AreEqual("TemplateStruct", unexposed.Name);
                     Assert.AreEqual(2, unexposed.TemplateParameters.Count);
-                    Assert.AreEqual(CppTemplateArgumentKind.AsType, unexposed.TemplateSpecializedArguments[0]?.ArgKind);
-                    Assert.AreEqual(CppPrimitiveKind.Int, (exposed.TemplateSpecializedArguments[0]?.ArgAsType as CppPrimitiveType).Kind);
-                    Assert.AreEqual("Struct2", (unexposed.TemplateSpecializedArguments[1].ArgAsType as CppClass)?.Name);
+                    Assert.AreEqual(CppTemplateArgumentKind.AsType, unexposed.TemplateArguments[0]?.ArgKind);
+                    Assert.AreEqual(CppPrimitiveKind.Int, (exposed.TemplateArguments[0]?.ArgAsType as CppPrimitiveType).Kind);
+                    Assert.AreEqual("Struct2", (unexposed.TemplateArguments[1].ArgAsType as CppClass)?.Name);
 
                     Assert.AreNotEqual(exposed.GetHashCode(), specialized.GetHashCode());
                     Assert.AreEqual(exposed.GetHashCode(), unexposed.GetHashCode());
@@ -141,7 +141,7 @@ class Derived : public ::BaseTemplate<::Derived>
                     Assert.AreEqual(1, baseClassSpecialized.TemplateParameters.Count);
 
                     //Here change to argument as a template deduce instance, not as a Template Parameters~~
-                    Assert.AreEqual(derived, baseClassSpecialized.TemplateSpecializedArguments[0].ArgAsType);
+                    Assert.AreEqual(derived, baseClassSpecialized.TemplateArguments[0].ArgAsType);
                     Assert.AreEqual(baseTemplate, baseClassSpecialized.PrimaryTemplate);
                 }
             );
@@ -184,19 +184,19 @@ foo<int, int> foobar;
                     //Need be a full specialized class for this field
                     Assert.AreEqual(field.Type, fullSpecializedClass);
 
-                    Assert.AreEqual(partialSpecializedTemplate.TemplateSpecializedArguments.Count, 2);
+                    Assert.AreEqual(partialSpecializedTemplate.TemplateArguments.Count, 2);
                     //The first argument is integer now
-                    Assert.AreEqual(partialSpecializedTemplate.TemplateSpecializedArguments[0].ArgString, "int");
+                    Assert.AreEqual(partialSpecializedTemplate.TemplateArguments[0].ArgString, "int");
                     //The second argument is not a specialized argument, we do not specialized a `B` template parameter here(partial specialized template)
-                    Assert.AreEqual(partialSpecializedTemplate.TemplateSpecializedArguments[1].IsSpecializedArgument, false);
+                    Assert.AreEqual(partialSpecializedTemplate.TemplateArguments[1].IsSpecializedArgument, false);
 
                     //The field use type is a full specialized type here~, so we can have two `int` template parmerater here
                     //It's a not template or partial template class, so we can instantiate it, see `foo<int, int> foobar;` before.
-                    Assert.AreEqual(fullSpecializedClass.TemplateSpecializedArguments.Count, 2);
+                    Assert.AreEqual(fullSpecializedClass.TemplateArguments.Count, 2);
                     //The first argument is integer now
-                    Assert.AreEqual(fullSpecializedClass.TemplateSpecializedArguments[0].ArgString, "int");
+                    Assert.AreEqual(fullSpecializedClass.TemplateArguments[0].ArgString, "int");
                     //The second argument is not a specialized argument
-                    Assert.AreEqual(fullSpecializedClass.TemplateSpecializedArguments[1].ArgString, "int");
+                    Assert.AreEqual(fullSpecializedClass.TemplateArguments[1].ArgString, "int");
                 }
             );
         }
@@ -254,10 +254,10 @@ void function1(std::tuple<double, double, double> input);
                 var parameterClass = parameter.Type as CppClass;
                 Assert.AreEqual(parameterClass.TemplateKind, CppTemplateKind.TemplateSpecializedClass);
                 Assert.AreEqual(parameterClass.Name, "tuple");
-                Assert.AreEqual(parameterClass.TemplateSpecializedArguments.Count, 3);
-                Assert.AreEqual(parameterClass.TemplateSpecializedArguments[0].ArgAsType.FullName, "double");
-                Assert.AreEqual(parameterClass.TemplateSpecializedArguments[1].ArgAsType.FullName, "double");
-                Assert.AreEqual(parameterClass.TemplateSpecializedArguments[2].ArgAsType.FullName, "double");
+                Assert.AreEqual(parameterClass.TemplateArguments.Count, 3);
+                Assert.AreEqual(parameterClass.TemplateArguments[0].ArgAsType.FullName, "double");
+                Assert.AreEqual(parameterClass.TemplateArguments[1].ArgAsType.FullName, "double");
+                Assert.AreEqual(parameterClass.TemplateArguments[2].ArgAsType.FullName, "double");
             });
         }
 
@@ -356,16 +356,28 @@ public:
                     Assert.AreEqual(templatedClass.Functions.Count, 2);
                     Assert.AreEqual(templatedClass.TemplateKind, CppTemplateKind.TemplateClass);
                     Assert.AreEqual(templatedClass.TemplateParameters.Count, 2);
-                    Assert.AreEqual(templatedClass.TemplateSpecializedArguments.Count, 0);
+                    Assert.AreEqual(templatedClass.TemplateArguments.Count, 2);
 
                     var T = templatedClass.TemplateParameters[0];
                     Assert.True(T is CppTemplateParameterType);
                     Assert.AreEqual((T as CppTemplateParameterType).Name, "T");
 
+                    var Targ = templatedClass.TemplateArguments[0];
+                    Assert.True(Targ is CppTemplateArgument);
+                    Assert.AreEqual((Targ as CppTemplateArgument).ArgKind, CppTemplateArgumentKind.AsType);
+                    Assert.AreEqual((Targ as CppTemplateArgument).ArgAsType.FullName, "T");
+                    Assert.AreEqual((Targ as CppTemplateArgument).SourceParam.FullName, "T");
+
                     var N = templatedClass.TemplateParameters[1];
                     Assert.True(N is CppTemplateParameterNonType);
                     Assert.AreEqual((N as CppTemplateParameterNonType).Name, "N");
                     Assert.AreEqual((N as CppTemplateParameterNonType).NoneTemplateType.GetDisplayName(), "unsigned int");
+
+                    var Narg = templatedClass.TemplateArguments[1];
+                    Assert.True(Narg is CppTemplateArgument);
+                    Assert.AreEqual((Narg as CppTemplateArgument).ArgKind, CppTemplateArgumentKind.AsExpression);
+                    Assert.AreEqual((Narg as CppTemplateArgument).ArgAsExpression.ToString(), "2");
+                    Assert.AreEqual((Narg as CppTemplateArgument).SourceParam.FullName, "unsigned int N");
 
                     var operatorPlus = templatedClass.Functions[0];
                     Assert.AreEqual(operatorPlus.Name, "operator+");
@@ -383,17 +395,29 @@ public:
                     var otherType = ((other.Type as CppReferenceType).ElementType as CppQualifiedType).ElementType as CppClass;
                     Assert.AreEqual(otherType.TemplateKind, CppTemplateKind.TemplateClass);
                     Assert.AreEqual(otherType.TemplateParameters.Count, 2);
-                    Assert.AreEqual(otherType.TemplateSpecializedArguments.Count, 0);
+                    Assert.AreEqual(otherType.TemplateArguments.Count, 2);
                     Assert.AreEqual(otherType.Name, "TemplatedClass");
 
                     T = otherType.TemplateParameters[0];
                     Assert.True(T is CppTemplateParameterType);
                     Assert.AreEqual((T as CppTemplateParameterType).Name, "T");
 
+                    Targ = otherType.TemplateArguments[0];
+                    Assert.True(Targ is CppTemplateArgument);
+                    Assert.AreEqual((Targ as CppTemplateArgument).ArgKind, CppTemplateArgumentKind.AsType);
+                    Assert.AreEqual((Targ as CppTemplateArgument).ArgAsType.FullName, "T");
+                    Assert.AreEqual((Targ as CppTemplateArgument).SourceParam.FullName, "T");
+
                     N = otherType.TemplateParameters[1];
                     Assert.True(N is CppTemplateParameterNonType);
                     Assert.AreEqual((N as CppTemplateParameterNonType).Name, "N");
                     Assert.AreEqual((N as CppTemplateParameterNonType).NoneTemplateType.GetDisplayName(), "unsigned int");
+
+                    Narg = otherType.TemplateArguments[1];
+                    Assert.True(Narg is CppTemplateArgument);
+                    Assert.AreEqual((Narg as CppTemplateArgument).ArgKind, CppTemplateArgumentKind.AsExpression);
+                    Assert.AreEqual((Narg as CppTemplateArgument).ArgAsExpression.ToString(), "2");
+                    Assert.AreEqual((Narg as CppTemplateArgument).SourceParam.FullName, "unsigned int N");
 
                     var operatorMinus = templatedClass.Functions[1];
                     Assert.AreEqual(operatorMinus.Name, "operator-");
@@ -411,17 +435,29 @@ public:
                     var other2Type = ((other2.Type as CppReferenceType).ElementType as CppQualifiedType).ElementType as CppClass;
                     Assert.AreEqual(other2Type.TemplateKind, CppTemplateKind.TemplateClass);
                     Assert.AreEqual(other2Type.TemplateParameters.Count, 2);
-                    Assert.AreEqual(otherType.TemplateSpecializedArguments.Count, 0);
+                    Assert.AreEqual(otherType.TemplateArguments.Count, 2);
                     Assert.AreEqual(other2Type.Name, "TemplatedClass");
 
                     T = other2Type.TemplateParameters[0];
                     Assert.True(T is CppTemplateParameterType);
                     Assert.AreEqual((T as CppTemplateParameterType).Name, "T");
 
+                    Targ = other2Type.TemplateArguments[0];
+                    Assert.True(Targ is CppTemplateArgument);
+                    Assert.AreEqual((Targ as CppTemplateArgument).ArgKind, CppTemplateArgumentKind.AsType);
+                    Assert.AreEqual((Targ as CppTemplateArgument).ArgAsType.FullName, "T");
+                    Assert.AreEqual((Targ as CppTemplateArgument).SourceParam.FullName, "T");
+
                     N = other2Type.TemplateParameters[1];
                     Assert.True(N is CppTemplateParameterNonType);
                     Assert.AreEqual((N as CppTemplateParameterNonType).Name, "N");
                     Assert.AreEqual((N as CppTemplateParameterNonType).NoneTemplateType.GetDisplayName(), "unsigned int");
+
+                    Narg = other2Type.TemplateArguments[1];
+                    Assert.True(Narg is CppTemplateArgument);
+                    Assert.AreEqual((Narg as CppTemplateArgument).ArgKind, CppTemplateArgumentKind.AsExpression);
+                    Assert.AreEqual((Narg as CppTemplateArgument).ArgAsExpression.ToString(), "2");
+                    Assert.AreEqual((Narg as CppTemplateArgument).SourceParam.FullName, "unsigned int N");
                 }
 
                 {
@@ -431,12 +467,17 @@ public:
                     Assert.AreEqual(templatedClass2D.Functions.Count, 2);
                     Assert.AreEqual(templatedClass2D.TemplateKind, CppTemplateKind.TemplateClass);
                     Assert.AreEqual(templatedClass2D.TemplateParameters.Count, 1);
-                    Assert.AreEqual(templatedClass2D.TemplateSpecializedArguments.Count, 0);
-
+                    Assert.AreEqual(templatedClass2D.TemplateArguments.Count, 1);
 
                     var T = templatedClass2D.TemplateParameters[0];
                     Assert.True(T is CppTemplateParameterType);
                     Assert.AreEqual((T as CppTemplateParameterType).Name, "T");
+
+                    var Targ = templatedClass2D.TemplateArguments[0];
+                    Assert.True(Targ is CppTemplateArgument);
+                    Assert.AreEqual((Targ as CppTemplateArgument).ArgKind, CppTemplateArgumentKind.AsType);
+                    Assert.AreEqual((Targ as CppTemplateArgument).ArgAsType.FullName, "T");
+                    Assert.AreEqual((Targ as CppTemplateArgument).SourceParam.FullName, "T");
 
                     var baseClass = templatedClass2D.BaseTypes[0].Type as CppClass;
                     Assert.AreEqual(baseClass, compilation.Classes[0]);
@@ -452,12 +493,18 @@ public:
                     var otherType = ((other.Type as CppReferenceType).ElementType as CppQualifiedType).ElementType as CppClass;
                     Assert.AreEqual(otherType.TemplateKind, CppTemplateKind.TemplateClass);
                     Assert.AreEqual(otherType.TemplateParameters.Count, 1);
-                    Assert.AreEqual(otherType.TemplateSpecializedArguments.Count, 0);
+                    Assert.AreEqual(otherType.TemplateArguments.Count, 1);
                     Assert.AreEqual(otherType.Name, "TemplatedClass2D");
 
                     T = otherType.TemplateParameters[0];
                     Assert.True(T is CppTemplateParameterType);
                     Assert.AreEqual((T as CppTemplateParameterType).Name, "T");
+
+                    Targ = templatedClass2D.TemplateArguments[0];
+                    Assert.True(Targ is CppTemplateArgument);
+                    Assert.AreEqual((Targ as CppTemplateArgument).ArgKind, CppTemplateArgumentKind.AsType);
+                    Assert.AreEqual((Targ as CppTemplateArgument).ArgAsType.FullName, "T");
+                    Assert.AreEqual((Targ as CppTemplateArgument).SourceParam.FullName, "T");
 
                     var operatorMinus = templatedClass2D.Functions[1];
                     Assert.AreEqual(operatorMinus.Name, "operator-");
@@ -470,13 +517,18 @@ public:
                     var other2Type = ((other2.Type as CppReferenceType).ElementType as CppQualifiedType).ElementType as CppClass;
                     Assert.AreEqual(other2Type.TemplateKind, CppTemplateKind.TemplateClass);
                     Assert.AreEqual(other2Type.TemplateParameters.Count, 1);
-                    Assert.AreEqual(otherType.TemplateSpecializedArguments.Count, 0);
+                    Assert.AreEqual(otherType.TemplateArguments.Count, 1);
                     Assert.AreEqual(other2Type.Name, "TemplatedClass2D");
 
                     T = other2Type.TemplateParameters[0];
                     Assert.True(T is CppTemplateParameterType);
                     Assert.AreEqual((T as CppTemplateParameterType).Name, "T");
 
+                    Targ = templatedClass2D.TemplateArguments[0];
+                    Assert.True(Targ is CppTemplateArgument);
+                    Assert.AreEqual((Targ as CppTemplateArgument).ArgKind, CppTemplateArgumentKind.AsType);
+                    Assert.AreEqual((Targ as CppTemplateArgument).ArgAsType.FullName, "T");
+                    Assert.AreEqual((Targ as CppTemplateArgument).SourceParam.FullName, "T");
                 }
             });
 
@@ -534,12 +586,12 @@ using TemplatedClassInt = TemplatedClass<int>;
             Assert.AreEqual(primaryTemplate.Functions.Count, specializedTemplate2.PrimaryTemplate.Functions.Count);
 
             Assert.AreEqual(specializedTemplate1.TemplateKind, CppTemplateKind.TemplateSpecializedClass);
-            Assert.AreEqual(specializedTemplate1.TemplateSpecializedArguments.Count, 1);
-            Assert.AreEqual(specializedTemplate1.TemplateSpecializedArguments[0].ArgAsType.FullName, "double");
+            Assert.AreEqual(specializedTemplate1.TemplateArguments.Count, 1);
+            Assert.AreEqual(specializedTemplate1.TemplateArguments[0].ArgAsType.FullName, "double");
 
             Assert.AreEqual(specializedTemplate2.TemplateKind, CppTemplateKind.TemplateSpecializedClass);
-            Assert.AreEqual(specializedTemplate2.TemplateSpecializedArguments.Count, 1);
-            Assert.AreEqual(specializedTemplate2.TemplateSpecializedArguments[0].ArgAsType.FullName, "int");
+            Assert.AreEqual(specializedTemplate2.TemplateArguments.Count, 1);
+            Assert.AreEqual(specializedTemplate2.TemplateArguments[0].ArgAsType.FullName, "int");
         });
         }
 
@@ -601,19 +653,19 @@ void function1(std::vector<Vect2> input);
             Assert.AreEqual(baseVector.TemplateParameters.Count, 2);
 
             Assert.AreEqual(vect2.TemplateKind, CppTemplateKind.TemplateSpecializedClass);
-            Assert.AreEqual(vect2.TemplateSpecializedArguments.Count, 2);
-            Assert.AreEqual(vect2.TemplateSpecializedArguments[0].ArgAsType.FullName, "double");
-            Assert.AreEqual(vect2.TemplateSpecializedArguments[1].ArgAsInteger, 2);
+            Assert.AreEqual(vect2.TemplateArguments.Count, 2);
+            Assert.AreEqual(vect2.TemplateArguments[0].ArgAsType.FullName, "double");
+            Assert.AreEqual(vect2.TemplateArguments[1].ArgAsInteger, 2);
 
             Assert.AreEqual(vect2i.TemplateKind, CppTemplateKind.TemplateSpecializedClass);
-            Assert.AreEqual(vect2i.TemplateSpecializedArguments.Count, 2);
-            Assert.AreEqual(vect2i.TemplateSpecializedArguments[0].ArgAsType.FullName, "int");
-            Assert.AreEqual(vect2i.TemplateSpecializedArguments[1].ArgAsInteger, 2);
+            Assert.AreEqual(vect2i.TemplateArguments.Count, 2);
+            Assert.AreEqual(vect2i.TemplateArguments[0].ArgAsType.FullName, "int");
+            Assert.AreEqual(vect2i.TemplateArguments[1].ArgAsInteger, 2);
 
             Assert.AreEqual(vect3.TemplateKind, CppTemplateKind.TemplateSpecializedClass);
-            Assert.AreEqual(vect3.TemplateSpecializedArguments.Count, 2);
-            Assert.AreEqual(vect3.TemplateSpecializedArguments[0].ArgAsType.FullName, "double");
-            Assert.AreEqual(vect3.TemplateSpecializedArguments[1].ArgAsInteger, 3);
+            Assert.AreEqual(vect3.TemplateArguments.Count, 2);
+            Assert.AreEqual(vect3.TemplateArguments[0].ArgAsType.FullName, "double");
+            Assert.AreEqual(vect3.TemplateArguments[1].ArgAsInteger, 3);
 
 
             var function1 = compilation.Functions[0];
@@ -624,17 +676,17 @@ void function1(std::vector<Vect2> input);
             var parameterClass = parameter.Type as CppClass;
             Assert.AreEqual(parameterClass.TemplateKind, CppTemplateKind.TemplateSpecializedClass);
             // The template argument is also a templated type
-            Assert.AreEqual(parameterClass.TemplateSpecializedArguments.Count, 2);
-            Assert.True(parameterClass.TemplateSpecializedArguments[0].ArgAsType is CppClass);
-            var argAsClass = parameterClass.TemplateSpecializedArguments[0].ArgAsType as CppClass;
+            Assert.AreEqual(parameterClass.TemplateArguments.Count, 2);
+            Assert.True(parameterClass.TemplateArguments[0].ArgAsType is CppClass);
+            var argAsClass = parameterClass.TemplateArguments[0].ArgAsType as CppClass;
             // The argument should be just the same as Vect2
             Assert.AreEqual(argAsClass.FullName, vect2.FullName);
             Assert.AreEqual(argAsClass.TemplateKind, vect2.TemplateKind);
-            Assert.AreEqual(argAsClass.TemplateSpecializedArguments.Count, vect2.TemplateSpecializedArguments.Count);
-            Assert.AreEqual(argAsClass.TemplateSpecializedArguments[0].ArgAsType.FullName,
-                            vect2.TemplateSpecializedArguments[0].ArgAsType.FullName);
-            Assert.AreEqual(argAsClass.TemplateSpecializedArguments[1].ArgAsInteger,
-                            vect2.TemplateSpecializedArguments[1].ArgAsInteger);
+            Assert.AreEqual(argAsClass.TemplateArguments.Count, vect2.TemplateArguments.Count);
+            Assert.AreEqual(argAsClass.TemplateArguments[0].ArgAsType.FullName,
+                            vect2.TemplateArguments[0].ArgAsType.FullName);
+            Assert.AreEqual(argAsClass.TemplateArguments[1].ArgAsInteger,
+                            vect2.TemplateArguments[1].ArgAsInteger);
 
         });
         }

--- a/src/CppAst/CppBaseType.cs
+++ b/src/CppAst/CppBaseType.cs
@@ -59,10 +59,10 @@ namespace CppAst
 
                 if (cls.TemplateKind == CppTemplateKind.TemplateSpecializedClass)
                 {
-                    for (var i = 0; i < cls.TemplateSpecializedArguments.Count; i++)
+                    for (var i = 0; i < cls.TemplateArguments.Count; i++)
                     {
                         if (i > 0) builder.Append(", ");
-                        builder.Append(cls.TemplateSpecializedArguments[i].ToString());
+                        builder.Append(cls.TemplateArguments[i].ToString());
                     }
                 }
                 else if (cls.TemplateKind == CppTemplateKind.TemplateClass)

--- a/src/CppAst/CppFunction.cs
+++ b/src/CppAst/CppFunction.cs
@@ -159,9 +159,9 @@ namespace CppAst
 
         public bool IsPureVirtual => ((int)Flags & (int)CppFunctionFlags.Pure) != 0;
 
-		public bool IsVirtual => ((int)Flags & (int)CppFunctionFlags.Virtual) != 0;
+        public bool IsVirtual => ((int)Flags & (int)CppFunctionFlags.Virtual) != 0;
 
-		public bool IsStatic => StorageQualifier == CppStorageQualifier.Static;
+        public bool IsStatic => StorageQualifier == CppStorageQualifier.Static;
 
         public bool IsConst => ((int)Flags & (int)CppFunctionFlags.Const) != 0;
 

--- a/src/CppAst/CppTemplateArgument.cs
+++ b/src/CppAst/CppTemplateArgument.cs
@@ -22,15 +22,23 @@ namespace CppAst
 
         public CppTemplateArgument(CppType sourceParam, long intArg) : base(CppTypeKind.TemplateArgumentType)
         {
-			SourceParam = sourceParam ?? throw new ArgumentNullException(nameof(sourceParam));
+            SourceParam = sourceParam ?? throw new ArgumentNullException(nameof(sourceParam));
             ArgAsInteger = intArg;
             ArgKind = CppTemplateArgumentKind.AsInteger;
             IsSpecializedArgument = true;
         }
 
-		public CppTemplateArgument(CppType sourceParam, string unknownStr) : base(CppTypeKind.TemplateArgumentType)
+        public CppTemplateArgument(CppType sourceParam, CppExpression typeArg) : base(CppTypeKind.TemplateArgumentType)
         {
-			SourceParam = sourceParam ?? throw new ArgumentNullException(nameof(sourceParam));
+            SourceParam = sourceParam ?? throw new ArgumentNullException(nameof(sourceParam));
+            ArgAsExpression = typeArg;
+            ArgKind = CppTemplateArgumentKind.AsExpression;
+            IsSpecializedArgument = true;
+        }
+
+        public CppTemplateArgument(CppType sourceParam, string unknownStr) : base(CppTypeKind.TemplateArgumentType)
+        {
+            SourceParam = sourceParam ?? throw new ArgumentNullException(nameof(sourceParam));
             ArgAsUnknown = unknownStr;
             ArgKind = CppTemplateArgumentKind.Unknown;
             IsSpecializedArgument = true;
@@ -39,6 +47,8 @@ namespace CppAst
         public CppTemplateArgumentKind ArgKind { get; }
 
         public CppType ArgAsType { get; }
+
+        public CppExpression ArgAsExpression { get; }
 
         public long ArgAsInteger { get; }
 
@@ -54,6 +64,8 @@ namespace CppAst
                         return ArgAsType.FullName;
                     case CppTemplateArgumentKind.AsInteger:
                         return ArgAsInteger.ToString();
+                    case CppTemplateArgumentKind.AsExpression:
+                        return ArgAsExpression.ToString();
                     case CppTemplateArgumentKind.Unknown:
                         return ArgAsUnknown;
                     default:
@@ -77,6 +89,30 @@ namespace CppAst
             set => throw new InvalidOperationException("This type does not support SizeOf");
         }
 
+        public bool Equals(CppTemplateArgument other)
+        {
+            if (ArgAsType != null && !ArgAsType.Equals(other.ArgAsType))
+            {
+                return false;
+            }
+
+            if (ArgAsExpression != null && !ArgAsExpression.Equals(other.ArgAsExpression))
+            {
+                return false;
+            }
+
+            if (ArgAsUnknown != null && !ArgAsUnknown.Equals(other.ArgAsUnknown))
+            {
+                return false;
+            }
+
+            return base.Equals(other) &&
+                ArgKind.Equals(other.ArgKind) &&
+                ArgAsInteger.Equals(other.ArgAsInteger) &&
+                SourceParam.Equals(other.SourceParam) &&
+                IsSpecializedArgument.Equals(other.IsSpecializedArgument);
+        }
+
         /// <inheritdoc />
         public override bool Equals(object obj)
         {
@@ -88,7 +124,28 @@ namespace CppAst
         {
             unchecked
             {
-                return (base.GetHashCode() * 397) ^ SourceParam.GetHashCode() ^ ArgString.GetHashCode();
+                var result = (base.GetHashCode() * 397) ^
+                    ArgKind.GetHashCode() ^
+                    ArgAsInteger.GetHashCode() ^
+                    SourceParam.GetHashCode() ^
+                    IsSpecializedArgument.GetHashCode();
+
+                if (ArgAsType != null)
+                {
+                    result ^= ArgAsType.GetHashCode();
+                }
+
+                if (ArgAsUnknown != null)
+                {
+                    result ^= ArgAsUnknown.GetHashCode();
+                }
+
+                if (ArgAsExpression != null)
+                {
+                    result ^= ArgAsExpression.GetHashCode();
+                }
+
+                return result;
             }
         }
 

--- a/src/CppAst/CppTemplateArgumentKind.cs
+++ b/src/CppAst/CppTemplateArgumentKind.cs
@@ -11,6 +11,7 @@ namespace CppAst
     {
         AsType,
         AsInteger,
+        AsExpression,
         Unknown,
     }
 

--- a/src/CppAst/CppTemplateParameterType.cs
+++ b/src/CppAst/CppTemplateParameterType.cs
@@ -3,6 +3,8 @@
 // See license.txt file in the project root for full license information.
 
 using System;
+using System.Collections.Generic;
+using System.Linq;
 
 namespace CppAst
 {
@@ -18,6 +20,13 @@ namespace CppAst
         public CppTemplateParameterType(string name) : base(CppTypeKind.TemplateParameterType)
         {
             Name = name ?? throw new ArgumentNullException(nameof(name));
+            TemplateTemplateParameters = new List<CppType>();
+        }
+
+        public CppTemplateParameterType(string name, System.Collections.Generic.List<CppType> templateTemplateParams) : base(CppTypeKind.TemplateParameterType)
+        {
+            Name = name ?? throw new ArgumentNullException(nameof(name));
+            TemplateTemplateParameters = templateTemplateParams;
         }
 
         /// <summary>
@@ -25,9 +34,16 @@ namespace CppAst
         /// </summary>
         public string Name { get; }
 
+        /// <summary>
+        /// Gets a list of the parameters.
+        /// </summary>
+        public List<CppType> TemplateTemplateParameters { get; }
+
         private bool Equals(CppTemplateParameterType other)
         {
-            return base.Equals(other) && Name.Equals(other.Name);
+            return base.Equals(other) && 
+              Name.Equals(other.Name) &&
+              TemplateTemplateParameters.SequenceEqual(other.TemplateTemplateParameters);
         }
 
         /// <inheritdoc />
@@ -48,7 +64,13 @@ namespace CppAst
         {
             unchecked
             {
-                return (base.GetHashCode() * 397) ^ Name.GetHashCode();
+                var hashCode = base.GetHashCode() * 397 ^ Name.GetHashCode();
+                foreach (var templateTemplateParameter in TemplateTemplateParameters)
+                {
+                    hashCode = (hashCode * 397) ^ templateTemplateParameter.GetHashCode();
+                }
+
+                return hashCode;
             }
         }
 

--- a/src/CppAst/CppType.cs
+++ b/src/CppAst/CppType.cs
@@ -27,7 +27,8 @@ namespace CppAst
 
         protected bool Equals(CppType other)
         {
-            return TypeKind == other.TypeKind;
+            return TypeKind.Equals(other.TypeKind) &&
+                SizeOf.Equals(other.SizeOf);
         }
 
         public override bool Equals(object obj)
@@ -40,7 +41,9 @@ namespace CppAst
         /// <inheritdoc />
         public override int GetHashCode()
         {
-            return (int)TypeKind;
+            return (base.GetHashCode() * 397) ^
+                TypeKind.GetHashCode() ^
+                SizeOf.GetHashCode();
         }
 
         /// <summary>


### PR DESCRIPTION
Template parameter resolution is half broken, e.g. all types should expose both template parameters and template arguments (resolved parameters), including unexposed types as well.

It must also work in a way that the same template parameter is being resolved multiple times (depending on how deep the resolution is in the STL callstack).