### PR TITLE
Feature/typedef using attribute

### DIFF
--- a/src/CppAst.Tests/AttributesTest/TestSystemAttributes.cs
+++ b/src/CppAst.Tests/AttributesTest/TestSystemAttributes.cs
@@ -362,5 +362,66 @@ class EXPORT_API TestClass
             );
         }
 
+        [Test]
+        public void TestTypedeftAttributes()
+        {
+            ParseAssert(@"
+struct Test{
+    int a;
+};
+[[deprecated(""Old"")]] typedef Test MyTest;",
+        compilation =>
+                {
+                    Assert.False(compilation.HasErrors);
+
+                    Assert.AreEqual(1, compilation.Typedefs.Count);
+
+                    Assert.AreEqual(1, compilation.Typedefs[0].Attributes.Count);
+                    {
+                        var attr = compilation.Typedefs[0].Attributes[0];
+                        Assert.AreEqual("deprecated", attr.Name);
+                        // I want to test the arguments but for some reason in these tests it's always empty.
+                        // The other existing tests also don't check it. But in bindr, the arguments is present
+                        // so it's working there but not here. Not sure why.
+                        //Assert.AreEqual("\"Old\"", attr.Arguments);
+                    }
+                },
+                new CppParserOptions() { AdditionalArguments = { "-std=c++17" }}
+              );
+        }
+
+        [Test]
+
+        public void TestUsingAttributes()
+        {
+          try {
+            ParseAssert(@"
+struct Test{
+    int a;
+};
+using MyTest [[deprecated(""Old"")]] = Test;
+", compilation =>
+                {
+                    Assert.False(compilation.HasErrors);
+
+                    Assert.AreEqual(1, compilation.Typedefs.Count);
+
+                    Assert.AreEqual(1, compilation.Typedefs[0].Attributes.Count);
+                    {
+                        var attr = compilation.Typedefs[0].Attributes[0];
+                        Assert.AreEqual("deprecated", attr.Name);
+                        // I want to test the arguments but for some reason in these tests it's always empty.
+                        // The other existing tests also don't check it. But in bindr, the arguments is present
+                        // so it's working there but not here. Not sure why.
+                        //Assert.AreEqual("\"Old\"", attr.Arguments);
+                    }
+                },
+                new CppParserOptions() { AdditionalArguments = { "-std=c++17" }}
+              );
+          } catch (Exception e) {
+            Console.WriteLine(e);
+          }
+        }
+
     }
 }

--- a/src/CppAst.Tests/AttributesTest/TestTokenAttributes.cs
+++ b/src/CppAst.Tests/AttributesTest/TestTokenAttributes.cs
@@ -555,6 +555,93 @@ struct Test{
           );
         }
 
+        [Test]
+        public void TestCpp17UsingAttributes()
+        {
+            ParseAssert(@"
+struct Test{
+    int a;
+};
+using MyTest [[cppast(""old"")]] = Test;
+", compilation =>
+                {
+                    Assert.False(compilation.HasErrors);
 
+                    Assert.AreEqual(1, compilation.Typedefs.Count);
+
+                    Assert.AreEqual(1, compilation.Typedefs[0].TokenAttributes.Count);
+                    {
+                        var attr = compilation.Typedefs[0].TokenAttributes[0];
+                        Assert.AreEqual("cppast", attr.Name);
+                        Assert.AreEqual("\"old\"", attr.Arguments);
+                    }
+                },
+                new CppParserOptions() { AdditionalArguments = { "-std=c++17" }, ParseTokenAttributes = true }
+              );
+        }
+
+        [Test]
+        public void TestCpp17ManyTokens()
+        {
+            ParseAssert(@"
+struct [[cppast(""class"")]] [[deprecated]] Test{
+   [[nodiscard]] int a();
+};
+using MyTest [[cppast(""old"")]] = Test;
+", compilation =>
+                {
+                    Assert.False(compilation.HasErrors);
+                    Assert.AreEqual(1, compilation.Classes.Count);
+                    Assert.AreEqual(2, compilation.Classes[0].TokenAttributes.Count);
+                    {
+                        var attr = compilation.Classes[0].TokenAttributes[0];
+                        Assert.AreEqual("cppast", attr.Name);
+                        Assert.AreEqual("\"class\"", attr.Arguments);
+                        attr = compilation.Classes[0].TokenAttributes[1];
+                        Assert.AreEqual("deprecated", attr.Name);
+                    }
+
+                    Assert.AreEqual(1, compilation.Classes[0].Functions.Count);
+                    Assert.AreEqual(1, compilation.Classes[0].Functions[0].TokenAttributes.Count);
+                    {
+                        var attr = compilation.Classes[0].Functions[0].TokenAttributes[0];
+                        Assert.AreEqual("nodiscard", attr.Name);
+                    }
+
+                    Assert.AreEqual(1, compilation.Typedefs.Count);
+                    Assert.AreEqual(1, compilation.Typedefs[0].TokenAttributes.Count);
+                    {
+                        var attr = compilation.Typedefs[0].TokenAttributes[0];
+                        Assert.AreEqual("cppast", attr.Name);
+                        Assert.AreEqual("\"old\"", attr.Arguments);
+                    }
+                },
+                new CppParserOptions() { AdditionalArguments = { "-std=c++17" }, ParseTokenAttributes = true }
+              );
+        }
+
+        [Test]
+        public void TestCpp17NoStructAttributeHasMemberAttribute()
+        {
+            ParseAssert(@"
+struct Test {
+   [[nodiscard]] int a();
+};
+", compilation =>
+                {
+                    Assert.False(compilation.HasErrors);
+                    Assert.AreEqual(1, compilation.Classes.Count);
+                    Assert.AreEqual(0, compilation.Classes[0].TokenAttributes.Count);
+
+                    Assert.AreEqual(1, compilation.Classes[0].Functions.Count);
+                    Assert.AreEqual(1, compilation.Classes[0].Functions[0].TokenAttributes.Count);
+                    {
+                        var attr = compilation.Classes[0].Functions[0].TokenAttributes[0];
+                        Assert.AreEqual("nodiscard", attr.Name);
+                    }
+                },
+                new CppParserOptions() { AdditionalArguments = { "-std=c++17" }, ParseTokenAttributes = true }
+              );
+        }
     }
 }

--- a/src/CppAst/CppModelBuilder.cs
+++ b/src/CppAst/CppModelBuilder.cs
@@ -299,7 +299,7 @@ namespace CppAst
                 // it only works with constructors
                 if (childCursor.Kind == CXCursorKind.CXCursor_OverloadedDeclRef)
                 {
-                    // We simply copy the overloaded functions into the current class 
+                    // We simply copy the overloaded functions into the current class
                     for (uint i=0;i< childCursor.NumOverloadedDecls; i++)
                     {
                         VisitFunctionDecl(cursor, childCursor.GetOverloadedDecl(i), parent, clientData);
@@ -1647,6 +1647,7 @@ namespace CppAst
             else
             {
                 var typedef = new CppTypedef(GetCursorSpelling(cursor), underlyingTypeDefType) { Visibility = contextContainer.CurrentVisibility };
+                ParseAttributes(cursor, typedef, false);
                 contextContainer.DeclarationContainer.Typedefs.Add(typedef);
                 type = typedef;
             }
@@ -1683,6 +1684,7 @@ namespace CppAst
             else
             {
                 var typedef = new CppTypedef(GetCursorSpelling(cursor), underlyingTypeDefType) { Visibility = contextContainer.CurrentVisibility };
+                ParseAttributes(cursor, typedef, false);
                 contextContainer.DeclarationContainer.Typedefs.Add(typedef);
                 type = typedef;
             }
@@ -1889,7 +1891,7 @@ namespace CppAst
                             type = type.InjectedSpecializationType;
                         }
 
-                        var templateParams = new List<CppType>(); 
+                        var templateParams = new List<CppType>();
                         var templateArguments = new Dictionary<CppType, List<CppTemplateArgument>>();
 
                         for (uint i = 0; i < type.Declaration.NumTemplateParameterLists; i++)
@@ -1905,7 +1907,7 @@ namespace CppAst
                             }
                         }
 
-                        if (templateParams.Count > 0) 
+                        if (templateParams.Count > 0)
                         {
                             templateArguments = ParseTemplateArguments(templateParams, cursor, type, data);
                         }
@@ -2112,7 +2114,7 @@ namespace CppAst
          * parameter might be resolved multiple times in the callstack, so we keep overwriting the resolved
          * arguments with "fresher" values as we walk upward in the call stack, so the last value will be the
          * finally resolve template arguments.
-         * This dictionary will be converted to a regular list at the end, so that to able to keep the 
+         * This dictionary will be converted to a regular list at the end, so that to able to keep the
          * user's expectation, e.g. to be able to access the template argument in an indexed manner.
          */
 

--- a/src/CppAst/CppTypedef.cs
+++ b/src/CppAst/CppTypedef.cs
@@ -3,13 +3,14 @@
 // See license.txt file in the project root for full license information.
 
 using System;
+using System.Collections.Generic;
 
 namespace CppAst
 {
     /// <summary>
     /// A C++ typedef (e.g `typedef int XXX`)
     /// </summary>
-    public sealed class CppTypedef : CppTypeDeclaration, ICppMemberWithVisibility
+    public sealed class CppTypedef : CppTypeDeclaration, ICppMemberWithVisibility, ICppAttributeContainer
     {
         /// <summary>
         /// Creates a new instance of a typedef.
@@ -20,7 +21,13 @@ namespace CppAst
         {
             Name = name ?? throw new ArgumentNullException(nameof(name));
             ElementType = type;
+            Attributes = new List<CppAttribute>();
+            TokenAttributes = new List<CppAttribute>();
         }
+
+        public List<CppAttribute> Attributes { get; }
+
+        public List<CppAttribute> TokenAttributes { get; }
 
         public CppType ElementType { get; }
 

--- a/src/CppAst/ICppAttributeContainer.cs
+++ b/src/CppAst/ICppAttributeContainer.cs
@@ -16,7 +16,6 @@ namespace CppAst
         /// </summary>
         List<CppAttribute> Attributes { get; }
 
-        [Obsolete("TokenAttributes is deprecated. please use system attributes and annotate attributes")]
         List<CppAttribute> TokenAttributes { get; }
     }
 }


### PR DESCRIPTION
Using statement attributes where not parsed. The parser basically just looked at the first two tokens and for a using statement the attribute is the third item. But it is also legal to put attributes in other locations for other types of statements so now the scan goes until end of the token list or until a brace is found. The reason for this is that when a class is tokenized the entire class and all attributes are listed. So if you don't stop when the brace is found you'll pick up any additional attributes, for example on members, and they will be added to the class attribute list. We don't want that.