### PR TITLE
Handle "signed char" and "char" correctly

### DIFF
--- a/src/CppAst.Tests/TestFunctions.cs
+++ b/src/CppAst.Tests/TestFunctions.cs
@@ -138,9 +138,9 @@ char function3(char);
                         Assert.AreEqual(1, cppFunction.Parameters.Count);
                         Assert.AreEqual(string.Empty, cppFunction.Parameters[0].Name);
                         Assert.AreEqual(CppTypeKind.Primitive, cppFunction.Parameters[0].Type.TypeKind);
-                        Assert.AreEqual(CppPrimitiveKind.UnsignedChar, ((CppPrimitiveType)cppFunction.Parameters[0].Type).Kind);
+                        Assert.AreEqual(CppPrimitiveKind.Char, ((CppPrimitiveType)cppFunction.Parameters[0].Type).Kind);
                         Assert.AreEqual(CppTypeKind.Primitive, cppFunction.ReturnType.TypeKind);
-                        Assert.AreEqual(CppPrimitiveKind.UnsignedChar, ((CppPrimitiveType)cppFunction.ReturnType).Kind);
+                        Assert.AreEqual(CppPrimitiveKind.Char, ((CppPrimitiveType)cppFunction.ReturnType).Kind);
                     }
                 },
                 options

--- a/src/CppAst.Tests/TestTypeAliases.cs
+++ b/src/CppAst.Tests/TestTypeAliases.cs
@@ -15,6 +15,7 @@ using Type_bool = bool;
 using Type_wchar = wchar_t ;
 
 using Type_char = char;
+using Type_signed_char = signed char;
 using Type_unsigned_char = unsigned char;
 
 using Type_short = short;
@@ -33,7 +34,7 @@ using Type_double = double;
                 {
                     Assert.False(compilation.HasErrors);
 
-                    Assert.AreEqual(13, compilation.Typedefs.Count);
+                    Assert.AreEqual(14, compilation.Typedefs.Count);
 
                     var primitives = new CppPrimitiveType[]
                     {
@@ -44,6 +45,7 @@ using Type_double = double;
                         CppPrimitiveType.WChar,
 
                         CppPrimitiveType.Char,
+                        CppPrimitiveType.SignedChar,
                         CppPrimitiveType.UnsignedChar,
 
                         CppPrimitiveType.Short,

--- a/src/CppAst.Tests/TestTypedefs.cs
+++ b/src/CppAst.Tests/TestTypedefs.cs
@@ -15,6 +15,7 @@ typedef bool Type_bool;
 typedef wchar_t Type_wchar;
 
 typedef char Type_char;
+typedef signed char Type_signed_char;
 typedef unsigned char Type_unsigned_char;
 
 typedef short Type_short;
@@ -33,7 +34,7 @@ typedef double Type_double;
                 {
                     Assert.False(compilation.HasErrors);
 
-                    Assert.AreEqual(13, compilation.Typedefs.Count);
+                    Assert.AreEqual(14, compilation.Typedefs.Count);
 
                     var primitives = new CppPrimitiveType[]
                     {
@@ -44,6 +45,7 @@ typedef double Type_double;
                         CppPrimitiveType.WChar,
 
                         CppPrimitiveType.Char,
+                        CppPrimitiveType.SignedChar,
                         CppPrimitiveType.UnsignedChar,
 
                         CppPrimitiveType.Short,

--- a/src/CppAst/CppModelBuilder.cs
+++ b/src/CppAst/CppModelBuilder.cs
@@ -1798,15 +1798,12 @@ namespace CppAst
                     return CppPrimitiveType.UnsignedLongLong;
 
                 case CXTypeKind.CXType_SChar:
-                    return CppPrimitiveType.Char;
+                    return CppPrimitiveType.SignedChar;
 
+                // 'char' is used for characters, it is an implementation detail of the ploatform if it's signed or not
                 case CXTypeKind.CXType_Char_S:
-                    return CppPrimitiveType.Char;
-
-                // CXTypeKind.CXType_Char_U is a char type with unsigned implementation.
-                // To keep the implementation consistent this will be mapped to unsigned char.
                 case CXTypeKind.CXType_Char_U:
-                    return CppPrimitiveType.UnsignedChar;
+                    return CppPrimitiveType.Char;
 
                 case CXTypeKind.CXType_WChar:
                     return CppPrimitiveType.WChar;

--- a/src/CppAst/CppPrimitiveKind.cs
+++ b/src/CppAst/CppPrimitiveKind.cs
@@ -30,6 +30,11 @@ namespace CppAst
         Char,
 
         /// <summary>
+        /// C++ `signed char`
+        /// </summary>
+        SignedChar,
+
+        /// <summary>
         /// C++ `short`
         /// </summary>
         Short,

--- a/src/CppAst/CppPrimitiveType.cs
+++ b/src/CppAst/CppPrimitiveType.cs
@@ -32,6 +32,11 @@ namespace CppAst
         public static readonly CppPrimitiveType Char = new CppPrimitiveType(CppPrimitiveKind.Char);
 
         /// <summary>
+        /// Singleton instance of the `signed char` type.
+        /// </summary>
+        public static readonly CppPrimitiveType SignedChar = new CppPrimitiveType(CppPrimitiveKind.SignedChar);
+
+        /// <summary>
         /// Singleton instance of the `short` type.
         /// </summary>
         public static readonly CppPrimitiveType Short = new CppPrimitiveType(CppPrimitiveKind.Short);
@@ -111,6 +116,9 @@ namespace CppAst
                 case CppPrimitiveKind.WChar:
                     sizeOf = 2;
                     break;
+                case CppPrimitiveKind.SignedChar:
+                    sizeOf = 1;
+                    break;
                 case CppPrimitiveKind.Char:
                     sizeOf = 1;
                     break;
@@ -160,6 +168,8 @@ namespace CppAst
                     return "wchar";
                 case CppPrimitiveKind.Char:
                     return "char";
+                case CppPrimitiveKind.SignedChar:
+                    return "signed char";
                 case CppPrimitiveKind.Short:
                     return "short";
                 case CppPrimitiveKind.Int:


### PR DESCRIPTION
 I have modified CppAst, so that it passes  CppPrimitiveType.Char type for non-qualified char (whether it is implemented as signed or unsigned), and  CppPrimitive.TypeSignedChar/ CppPrimitiveType.UnsignedChar for the qualified types.